### PR TITLE
Ms3744 patch tokenize dataset

### DIFF
--- a/miditok/midi_tokenizer_base.py
+++ b/miditok/midi_tokenizer_base.py
@@ -234,7 +234,11 @@ class MIDITokenizer:
         :param logging: logs a progress bar
         """
         Path(out_dir).mkdir(parents=True, exist_ok=True)
-
+        
+        # Making a directory of the parent folders for the JSON file
+#         parent_dir = PurePath(midi_paths[0]).parent[0]
+#         PurePath(out_dir, parent_dir).mkdir(parents=True, exist_ok=True)
+            
         for m, midi_path in enumerate(midi_paths):
             if logging:
                 bar_len = 60
@@ -258,9 +262,8 @@ class MIDITokenizer:
 
             # Converting the MIDI to tokens and saving them as json
             tokens, track_info = self.midi_to_tokens(midi)
-            # Making a directory for the JSON file
-            PurePath(out_dir, midi_path).mkdir(parents=True, exist_ok=True)
-            with open(PurePath(out_dir, midi_path).with_suffix(".json"), 'w') as outfile:
+            midi_name = PurePath(midi_path).stem
+            with open(PurePath(out_dir, midi_name).with_suffix(".json"), 'w') as outfile:
                 json.dump([tokens[0], track_info[0]], outfile)
 
         self.save_params(out_dir)  # Saves the parameters with which the MIDIs are converted

--- a/miditok/midi_tokenizer_base.py
+++ b/miditok/midi_tokenizer_base.py
@@ -258,6 +258,8 @@ class MIDITokenizer:
 
             # Converting the MIDI to tokens and saving them as json
             tokens, track_info = self.midi_to_tokens(midi)
+            # Making a directory for the JSON file
+            PurePath(out_dir, midi_path).mkdir(parents=True, exist_ok=True)
             with open(PurePath(out_dir, midi_path).with_suffix(".json"), 'w') as outfile:
                 json.dump([tokens[0], track_info[0]], outfile)
 


### PR DESCRIPTION
The current version of the function does not work well with midi paths with directories with them in python notebooks, this is because a directory has to created before a file can be stored. For example, if the midi path is `a/b/c.mid`,  and the output directory is `d/e` then the code gives an error unless `d/e/a/b/` directory exists. 
<br/>
This PR will automatically take the name of the MIDI file and saves it in the directory as `d/e/c.json`. There is a commented code in line 239 if we want to concatenate the entire path as `d/e/a/b/c.mid.json`