### PR TITLE
Speed up midi_to_tokens

### DIFF
--- a/miditok/cp_word.py
+++ b/miditok/cp_word.py
@@ -62,6 +62,7 @@ class CPWordEncoding(MIDITokenizer):
         # notes.sort(key=lambda x: (x.start, x.pitch))  # done in midi_to_tokens
         ticks_per_sample = self.current_midi_metadata['time_division'] / max(self.beat_res.values())
         ticks_per_bar = self.current_midi_metadata['time_division'] * 4
+        dur_bins = self.durations_ticks[self.current_midi_metadata['time_division']]
         min_rest = self.current_midi_metadata['time_division'] * self.rests[0][0] + ticks_per_sample * self.rests[0][1]\
             if self.additional_tokens['Rest'] else 0
         tokens = []  # list of lists of tokens
@@ -125,8 +126,7 @@ class CPWordEncoding(MIDITokenizer):
 
             # Note
             duration = note.end - note.start
-            dur_index = np.argmin(np.abs([ticks - duration for ticks in
-                                          self.durations_ticks[self.current_midi_metadata['time_division']]]))
+            dur_index = np.argmin(np.abs(dur_bins - duration))
             dur_value = '.'.join(map(str, self.durations[dur_index]))
             tokens.append(self.create_cp_token(int(note.start), pitch=note.pitch, vel=note.velocity, dur=dur_value,
                                                desc=f'{duration} ticks'))

--- a/miditok/midi_like.py
+++ b/miditok/midi_like.py
@@ -51,6 +51,7 @@ class MIDILikeEncoding(MIDITokenizer):
         # Make sure the notes are sorted first by their onset (start) times, second by pitch
         # notes.sort(key=lambda x: (x.start, x.pitch))  # done in midi_to_tokens
         ticks_per_sample = self.current_midi_metadata['time_division'] / max(self.beat_res.values())
+        dur_bins = self.durations_ticks[self.current_midi_metadata['time_division']]
         min_rest = self.current_midi_metadata['time_division'] * self.rests[0][0] + ticks_per_sample * self.rests[0][1]\
             if self.additional_tokens['Rest'] else 0
         events = []
@@ -106,16 +107,14 @@ class MIDILikeEncoding(MIDITokenizer):
                 # Adds an additional time shift if needed
                 if rest_pos > 0:
                     time_shift = round(rest_pos * ticks_per_sample)
-                    index = np.argmin(np.abs([ticks - time_shift for ticks in
-                                              self.durations_ticks[self.current_midi_metadata['time_division']]]))
+                    index = np.argmin(np.abs(dur_bins - time_shift))
                     events.append(Event(type_='Time-Shift', time=previous_tick,
                                         value='.'.join(map(str, self.durations[index])), desc=f'{time_shift} ticks'))
 
             # Time shift
             else:
                 time_shift = event.time - previous_tick
-                index = np.argmin(np.abs([ticks - time_shift for ticks in
-                                          self.durations_ticks[self.current_midi_metadata['time_division']]]))
+                index = np.argmin(np.abs(dur_bins - time_shift))
                 events.append(Event(type_='Time-Shift', time=previous_tick,
                                     value='.'.join(map(str, self.durations[index])), desc=f'{time_shift} ticks'))
 

--- a/miditok/midi_tokenizer_base.py
+++ b/miditok/midi_tokenizer_base.py
@@ -46,8 +46,7 @@ class MIDITokenizer:
 
         # Init duration and velocity values
         self.durations = self.__create_durations_tuples()
-        self.velocities = list(np.linspace(0, 127, self.nb_velocities + 1, dtype=np.intc))
-        del self.velocities[0]  # removes velocity 0
+        self.velocities = np.linspace(0, 127, self.nb_velocities + 1, dtype=np.intc)[1:]  # remove velocity 0
         self._first_beat_res = list(beat_res.values())[0]
         for beat_range, res in beat_res.items():
             if 0 in beat_range:
@@ -232,7 +231,7 @@ class MIDITokenizer:
             if notes[i].start == notes[i].end:  # if this happens to often, consider using a higher beat resolution
                 notes[i].end += ticks_per_sample  # like 8 samples per beat or 24 samples per bar
 
-            notes[i].velocity = min(self.velocities, key=lambda x: abs(x - notes[i].velocity))
+            notes[i].velocity = self.velocities[np.argmin(np.abs(self.velocities - notes[i].velocity))]
             i += 1
 
     def quantize_tempos(self, tempos: List[TempoChange], time_division: int):
@@ -247,7 +246,7 @@ class MIDITokenizer:
         i = 0
         while i < len(tempos):
             # Quantize tempo value
-            tempos[i].tempo = min(self.tempos, key=lambda x: abs(x - tempos[i].tempo))
+            tempos[i].tempo = self.tempos[np.argmin(np.abs(self.tempos - tempos[i].tempo))]
             if tempos[i].tempo == prev_tempo:
                 del tempos[i]
                 continue

--- a/miditok/midi_tokenizer_base.py
+++ b/miditok/midi_tokenizer_base.py
@@ -87,11 +87,9 @@ class MIDITokenizer:
         :return: the token representation, i.e. tracks converted into sequences of tokens
         """
         # Check if the durations values have been calculated before for this time division
-        try:
-            _ = self.durations_ticks[midi.ticks_per_beat]
-        except KeyError:
-            self.durations_ticks[midi.ticks_per_beat] = [(beat * res + pos) * midi.ticks_per_beat // res
-                                                         for beat, pos, res in self.durations]
+        if midi.ticks_per_beat not in self.durations_ticks:
+            self.durations_ticks[midi.ticks_per_beat] = np.array([(beat * res + pos) * midi.ticks_per_beat // res
+                                                                  for beat, pos, res in self.durations])
 
         # Preprocess the MIDI file
         self.preprocess_midi(midi)

--- a/miditok/octuple_mono.py
+++ b/miditok/octuple_mono.py
@@ -76,6 +76,7 @@ class OctupleMonoEncoding(MIDITokenizer):
         # notes.sort(key=lambda x: (x.start, x.pitch))  # done in midi_to_tokens
         ticks_per_sample = self.current_midi_metadata['time_division'] / max(self.beat_res.values())
         ticks_per_bar = self.current_midi_metadata['time_division'] * 4
+        dur_bins = self.durations_ticks[self.current_midi_metadata['time_division']]
 
         # Check bar embedding limit, update if needed
         nb_bars = ceil(max(note.end for note in track.notes) / (self.current_midi_metadata['time_division'] * 4))
@@ -99,8 +100,7 @@ class OctupleMonoEncoding(MIDITokenizer):
 
             # Note attributes
             duration = note.end - note.start
-            dur_index = np.argmin(np.abs([ticks - duration for ticks in
-                                          self.durations_ticks[self.current_midi_metadata['time_division']]]))
+            dur_index = np.argmin(np.abs(dur_bins - duration))
             token_ts = [self.vocab.event_to_token[f'Pitch_{note.pitch}'],
                         self.vocab.event_to_token[f'Velocity_{note.velocity}'],
                         self.vocab.event_to_token[f'Duration_{".".join(map(str, self.durations[dur_index]))}'],

--- a/miditok/remi.py
+++ b/miditok/remi.py
@@ -42,6 +42,7 @@ class REMIEncoding(MIDITokenizer):
         # notes.sort(key=lambda x: (x.start, x.pitch))  # done in midi_to_tokens
         ticks_per_sample = self.current_midi_metadata['time_division'] / max(self.beat_res.values())
         ticks_per_bar = self.current_midi_metadata['time_division'] * 4
+        dur_bins = self.durations_ticks[self.current_midi_metadata['time_division']]
         min_rest = self.current_midi_metadata['time_division'] * self.rests[0][0] + ticks_per_sample * self.rests[0][1]\
             if self.additional_tokens['Rest'] else 0
 
@@ -108,8 +109,7 @@ class REMIEncoding(MIDITokenizer):
             events.append(Event(type_='Pitch', time=note.start, value=note.pitch, desc=note.pitch))
             events.append(Event(type_='Velocity', time=note.start, value=note.velocity, desc=f'{note.velocity}'))
             duration = note.end - note.start
-            index = np.argmin(np.abs([ticks - duration for ticks in
-                                      self.durations_ticks[self.current_midi_metadata['time_division']]]))
+            index = np.argmin(np.abs(dur_bins - duration))
             events.append(Event(type_='Duration', time=note.start, value='.'.join(map(str, self.durations[index])),
                                 desc=f'{duration} ticks'))
 

--- a/miditok/structured.py
+++ b/miditok/structured.py
@@ -59,7 +59,7 @@ class StructuredEncoding(MIDITokenizer):
                 time_shift = track.notes[0].start % self.current_midi_metadata['time_division']  # beat wise
             else:
                 time_shift = track.notes[0].start
-            index = np.argmin(np.abs([ticks - time_shift for ticks in dur_bins]))
+            index = np.argmin(np.abs(dur_bins - time_shift))
             events.append(Event(type_='Time-Shift', time=0, value='.'.join(map(str, self.durations[index])),
                                 desc=f'{time_shift} ticks'))
 
@@ -71,12 +71,12 @@ class StructuredEncoding(MIDITokenizer):
             events.append(Event(type_='Velocity', time=note.start, value=note.velocity, desc=f'{note.velocity}'))
             # Duration
             duration = note.end - note.start
-            index = np.argmin(np.abs([ticks - duration for ticks in dur_bins]))
+            index = np.argmin(np.abs(dur_bins - duration))
             events.append(Event(type_='Duration', time=note.start, value='.'.join(map(str, self.durations[index])),
                                 desc=f'{duration} ticks'))
             # Time-Shift
             time_shift = track.notes[n + 1].start - note.start
-            index = np.argmin(np.abs([ticks - time_shift for ticks in dur_bins]))
+            index = np.argmin(np.abs(dur_bins - time_shift))
             events.append(Event(type_='Time-Shift', time=note.start, desc=f'{time_shift} ticks',
                                 value='.'.join(map(str, self.durations[index])) if time_shift != 0 else '0.0.1'))
         # Adds the last note
@@ -89,7 +89,7 @@ class StructuredEncoding(MIDITokenizer):
             events.append(Event(type_='Velocity', time=track.notes[-1].start, value=track.notes[-1].velocity,
                                 desc=f'{track.notes[-1].velocity}'))
             duration = track.notes[-1].end - track.notes[-1].start
-            index = np.argmin(np.abs([ticks - duration for ticks in dur_bins]))
+            index = np.argmin(np.abs(dur_bins - duration))
             events.append(Event(type_='Duration', time=track.notes[-1].start,
                                 value='.'.join(map(str, self.durations[index])), desc=f'{duration} ticks'))
 


### PR DESCRIPTION
Hi, thanks for the great repository! I plan to use it for my research purposes, so probably, this is not my last pull request :) 

I have been playing around with the encodings and, after code profiling, I found a few computational bottlenecks in `midi_to_tokens`:
1. Encoding of `Duration`/`Time-Shift` tokens
2. Quantization of `Velocity`
3. Quantization of `Tempo`

List comprehensions (especially for durations) take more than half of the computation time of `midi_to_tokens`. Since NumPy is one of the library dependencies, it is beneficial to utilize it instead of pure Python code. Hopefully, I covered all relevant cases.

The overall speedups for different tokenizations might range from a few percent to x2-3. For example, the tests (with much other stuff) run x1.5 faster on my setup.