### PR TITLE
[WIP] Time signature tokens

### DIFF
--- a/miditok/constants.py
+++ b/miditok/constants.py
@@ -10,16 +10,20 @@ NB_VELOCITIES = 32  # nb of velocity bins, velocities values from 0 to 127 will 
 ADDITIONAL_TOKENS = {'Chord': False,
                      'Rest': False,
                      'Tempo': False,
+                     'TimeSignature': False,
                      'Program': False,
                      # rest params
                      'rest_range': (2, 8),  # (/min_rest, max_rest_in_BEAT), first divides a whole note/rest
                      # tempo params
                      'nb_tempos': 32,  # nb of tempo bins for additional tempo tokens, quantized like velocities
-                     'tempo_range': (40, 250)}  # (min_tempo, max_tempo)
+                     'tempo_range': (40, 250),  # (min_tempo, max_tempo)
+                     # time signature params
+                     'time_signature_range': (8, 2)}  # (max_beat_res, max_bar_length_in_NOTE)
 
 # Defaults values when writing new MIDI files
 TIME_DIVISION = 384  # 384 and 480 are convenient as divisible by 4, 8, 12, 16, 24, 32
 TEMPO = 120
+TIME_SIGNATURE = (4, 4)
 
 CHORD_MAPS = {'min': (0, 3, 7),
               'maj': (0, 4, 7),

--- a/tests/tests_utils.py
+++ b/tests/tests_utils.py
@@ -4,7 +4,7 @@
 
 from typing import Tuple, List, Union
 
-from miditoolkit import MidiFile, Instrument, Note, TempoChange
+from miditoolkit import MidiFile, Instrument, Note, TempoChange, TimeSignature
 
 
 def midis_equals(midi1: MidiFile, midi2: MidiFile) -> List[Tuple[int, str, List[Tuple[str, Union[Note, int], int]]]]:
@@ -40,13 +40,26 @@ def notes_equals(note1: Note, note2: Note) -> str:
 
 
 def tempo_changes_equals(tempo_changes1: List[TempoChange], tempo_changes2: List[TempoChange]) \
-        -> List[Tuple[str, float]]:
+        -> List[Tuple[str, TempoChange, float]]:
     errors = []
     for tempo_change1, tempo_change2 in zip(tempo_changes1, tempo_changes2):
         if tempo_change1.time != tempo_change2.time:
-            errors.append(('time', tempo_change2.time))
+            errors.append(('time', tempo_change1, tempo_change2.time))
         if tempo_change1.tempo != tempo_change2.tempo:
-            errors.append(('tempo', tempo_change2.time))
+            errors.append(('tempo', tempo_change1, tempo_change2.tempo))
+    return errors
+
+
+def time_signature_changes_equals(time_sig_changes1: List[TimeSignature], time_sig_changes2: List[TimeSignature]) \
+        -> List[Tuple[str, TimeSignature, float]]:
+    errors = []
+    for time_sig_change1, time_sig_change2 in zip(time_sig_changes1, time_sig_changes2):
+        if time_sig_change1.time != time_sig_change2.time:
+            errors.append(('time', time_sig_change1, time_sig_change2.time))
+        if time_sig_change1.numerator != time_sig_change2.numerator:
+            errors.append(('numerator', time_sig_change1, time_sig_change2.numerator))
+        if time_sig_change1.denominator != time_sig_change2.denominator:
+            errors.append(('denominator', time_sig_change1, time_sig_change2.denominator))
     return errors
 
 


### PR DESCRIPTION
Hi! Here is some contribution to MidiTok: time signature changes and tokens!

Time Signatures are listed as TODO in readme. I don't know the current status, but I would love to share my almost complete implementation for a review. I work with OctupleMIDI encoding and music primarily not in 4/4, so I implemented the core time signature processing and support for `TimeSignature` tokens in `Octuple` encoding.

I used MusicBERT's Octuple encoding as a reference. Time signature vocabulary is constructed similarly to the process introduced in MusicBERT [paper](https://arxiv.org/pdf/2106.05630.pdf) and [code](https://github.com/microsoft/muzic/blob/main/musicbert/preprocess.py#L57-L62) for Octuple encoding. Time signature reduction is also borrowed from MusicBERT.

The current code supports `TimeSignature` tokens only for `Octuple` encoding but probably may be embedded in other encodings. The obvious choice is `OctupleMono`, but it requires changing the interface of `tokens_to_track`, so I omitted to change it for now.

For the quality checks, the tests do not fail for 4/4 music. Also, Octuple encoding and decoding work correctly on MIDI files with arbitrary time signatures changes (unless Octuple encoding theoretically does not allow it, e.g., time signatures tie to notes and change their actual positions, decoding fails).

Work done:
1. `TimeSignature` as a configurable additional token
2. Fix `ticks_per_bar` for arbitrary time signatures in `quantize_time_signatures()`
3. Support for time signature processing in `MIDITokenizer`:
    * `__create_time_signatures()`
    * `_reduce_time_signature()`
    * `_parse_token_time_signature()`
4. Implement `TimeSignature` token encoding/decoding in `Octuple` encoding
5. Update tests with support for time signature changes checks (`Octuple` encoding only)

Work to be done:
1. Process `additional_tokens['TimeSignature']` parameter in all encodings (tokenizer initializations will fail if the parameter is not specified)
2. Extend test MIDI files with music not in 4/4 
3. Update README
4. (Optional) Implement `TimeSignature` tokens in other encodings 

I hope the code is self-explanatory, and I am ready to change/improve it if needed. 
