### PR TITLE
Fix the "no pad_token_id" bug in generation

### DIFF
--- a/colab-notebooks/Full_Example_HuggingFace_GPT2_Transformer.ipynb
+++ b/colab-notebooks/Full_Example_HuggingFace_GPT2_Transformer.ipynb
@@ -339,6 +339,7 @@
     "    top_p=0.95,\n",
     "    epsilon_cutoff=3e-4,\n",
     "    eta_cutoff=1e-3,\n",
+    "    pad_token_id=config.padding_token_id,\n",
     ")\n",
     "\n",
     "(gen_results_path := Path('gen_res')).mkdir(parents=True, exist_ok=True)\n",


### PR DESCRIPTION
just fixed the bug in "Generate Music" as following:
```
ValueError: If `eos_token_id` is defined, make sure that `pad_token_id` is defined.
```
added pad_token_id definition in GenerationConfig.