### PR TITLE
Fix MIDITokenizer.__repr__ and test

### DIFF
--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -1873,10 +1873,14 @@ class MIDITokenizer(ABC):
         return [len(v) for v in self.vocab] if self.is_multi_voc else len(self)
 
     def __repr__(self):
-        return (
-            f'{len(self.len)} tokens {"(multi-voc) " if self.is_multi_voc else ""}'
-            f'{"with BPE" if self.has_bpe else "without BPE"}'
-        )
+        out_str = f"{self.len} tokens"
+        if self.is_multi_voc:
+            out_str += " (multi-voc)"
+        if self.has_bpe:
+            out_str += " with BPE"
+        else:
+            out_str += " without BPE"
+        return out_str
 
     def __getitem__(
         self, item: Union[int, str, Tuple[int, Union[int, str]]]

--- a/tests/test_one_track.py
+++ b/tests/test_one_track.py
@@ -88,6 +88,9 @@ def test_one_track_midi_to_tokens_to_midi(
                 additional_tokens=add_tokens,
             )
 
+            # printing the tokenizer shouldn't fail
+            _ = str(tokenizer)
+
             # Convert the track in tokens
             tokens = tokenizer(midi)
             if not tokenizer.unique_track:  # or isinstance list


### PR DESCRIPTION
This change addresses a bug in `MIDITokenizer.__repr__`, which causes the code to crash when attempting to print a `MIDITokenizer` for which `tokenizer.is_multi_voc == False`.

A minimal working example of this bug:
```
>>> from miditok import REMI
>>> print(REMI())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dt/code/scratch/MidiTok/miditok/midi_tokenizer.py", line 1877, in __repr__
    f'{len(self.len)} tokens {"(multi-voc) " if self.is_multi_voc else ""}'
       ^^^^^^^^^^^^^
TypeError: object of type 'int' has no len()
```

Note that the output string for tokenizers with multiple vocabularies is now different than it was previously. Previously:
```
>>> from miditok import Octuple
>>> print(Octuple())
6 tokens (multi-voc) without BPE
```
and now:
```
>>> from miditok import Octuple
>>> print(Octuple())
[92, 36, 68, 133, 36, 64] tokens (multi-voc) without BPE
```
Personally I find this to be more informative, but I can change it back if you'd prefer.

Finally, I add a slight modification to `tests/test_one_track.py` to make sure `str(tokenizer)` doesn't fail for each of the tokenizers.