### PR TITLE
Fix PitchBend time attribute

### DIFF
--- a/miditok/utils/utils.py
+++ b/miditok/utils/utils.py
@@ -302,7 +302,7 @@ def merge_tracks(
         tracks_[0].control_changes.sort(key=lambda control_change: control_change.time)
         # Pitch bends
         tracks_[0].pitch_bends = sum((t.pitch_bends for t in tracks_), [])
-        tracks_[0].pitch_bends.sort(key=lambda pitch_bend: pitch_bend.start)
+        tracks_[0].pitch_bends.sort(key=lambda pitch_bend: pitch_bend.time)
 
     # Keeps only one track
     if isinstance(tracks, MidiFile):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,14 @@ def test_merge_tracks():
     merge_tracks(midi.instruments)
     assert len(midi.instruments[0].notes) == 2 * len(original_track.notes)
 
+    # Test merge with effects
+    midi.instruments.append(deepcopy(midi.instruments[0]))
+    merge_tracks(midi, effects=True)
+    assert len(midi.instruments[0].notes) == 4 * len(original_track.notes)
+    assert len(midi.instruments[0].pedals) == 2 * len(original_track.pedals)
+    assert len(midi.instruments[0].control_changes) == 2 * len(original_track.control_changes)
+    assert len(midi.instruments[0].pitch_bends) == 2 * len(original_track.pitch_bends)
+
 
 def test_merge_same_program_tracks_and_by_class():
     multitrack_midi_paths = list(Path("tests", "Multitrack_MIDIs").glob("**/*.mid"))


### PR DESCRIPTION
[miditoolkit's `PitchBend`](https://github.com/YatingMusic/miditoolkit/blob/9835be29e42fbc23529d61273820707ccfa189f4/miditoolkit/midi/containers.py#L54-L71) has no attribute `start`, this PR fixes the bug in `merge_tracks` function.