### PR TITLE
New TokenizerConfig object, and method to instantiate tokenizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ MidiTok uses [MIDIToolkit](https://github.com/YatingMusic/miditoolkit), which it
 The most basic and useful methods are summarized here. And [here](colab-notebooks/Full_Example_HuggingFace_GPT2_Transformer.ipynb) is a simple notebook example showing how to use Hugging Face models to generate music, with MidiTok taking care of tokenizing MIDIs.
 
 ```python
-from miditok import REMI
+from miditok import REMI, TokenizerConfig
 from miditok.utils import get_midi_programs
 from miditoolkit import MidiFile
 from pathlib import Path
 
+# Creating the tokenizer's configuration, read the doc to explore other parameters
+config = TokenizerConfig(nb_velocities=16, use_chords=True)
+
 # Creates the tokenizer and loads a MIDI
-tokenizer = REMI()  # using the default parameters, read the documentation to customize your tokenizer
+tokenizer = REMI(config)
 midi = MidiFile('path/to/your_midi.mid')
 
 # Converts MIDI to tokens, and back to a MIDI
@@ -57,7 +60,7 @@ tokenizer.learn_bpe(
 )
 
 # Saving our tokenizer, to retrieve it back later with the load_params method
-tokenizer.save_params(Path("path", "to", "save", "tokenizer"))
+tokenizer.save_params(Path("path", "to", "save", "tokenizer.json"))
 
 # Converts the tokenized musics into tokens with BPE
 tokenizer.apply_bpe_to_dataset(Path('path', 'to', 'tokens_noBPE'), Path('path', 'to', 'tokens_BPE'))
@@ -89,11 +92,12 @@ Contributions are gratefully welcomed, feel free to open an issue or send a PR i
 
 ### Todos
 
-* Extend Time Signature to all tokenizations
-* Control Change messages
-* Option to represent pitch values as pitch intervals, as [it seems to improve performances](https://ismir2022program.ismir.net/lbd_369.html).
-* Speeding up MIDI read / load (Rust / C++ binding)
-* Data augmentation on duration values at the MIDI level
+* Option to place `Program` tokens before note tokens for *TSD*, "vanilla" *REMI*, *MIDI-Like* and *Structured*;
+* Extend Time Signature to all tokenizations;
+* Control Change messages;
+* Option to represent pitch values as pitch intervals, as [it seems to improve performances](https://ismir2022program.ismir.net/lbd_369.html);
+* Speeding up MIDI read / load (using a Rust / C++ io library + Python binding ?);
+* Data augmentation on duration values at the MIDI level.
 
 ## Citation
 

--- a/miditok/__init__.py
+++ b/miditok/__init__.py
@@ -11,7 +11,7 @@ from .tokenizations import (
     MMM,
 )
 from .midi_tokenizer import MIDITokenizer
-from .classes import Event, TokSequence
+from .classes import Event, TokSequence, TokenizerConfig
 
 from .utils import utils
 from .data_augmentation import data_augmentation

--- a/miditok/classes.py
+++ b/miditok/classes.py
@@ -255,13 +255,17 @@ class TokenizerConfig:
         config = cls(**input_dict, **kwargs)
         return config
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self, serialize: bool = False) -> Dict[str, Any]:
         r"""
         Serializes this instance to a Python dictionary.
 
+        :param serialize: will serialize the dictionary before returning it, so it can be saved to a JSON file.
         :return: Dictionary of all the attributes that make up this configuration instance.
         """
-        return deepcopy(self.__dict__)
+        dict_config = deepcopy(self.__dict__)
+        if serialize:
+            self.__serialize_dict(dict_config)
+        return dict_config
 
     def __serialize_dict(self, dict_: Dict):
         r"""
@@ -285,8 +289,7 @@ class TokenizerConfig:
             out_path = Path(out_path)
         out_path.parent.mkdir(parents=True, exist_ok=True)
 
-        dict_config = self.to_dict()
-        self.__serialize_dict(dict_config)
+        dict_config = self.to_dict(serialize=True)
         dict_config["beat_res"] = {
             f"{k1}_{k2}": v for (k1, k2), v in dict_config["beat_res"].items()
         }

--- a/miditok/classes.py
+++ b/miditok/classes.py
@@ -1,5 +1,26 @@
 from dataclasses import dataclass
-from typing import Union, Any, List
+from typing import Union, Any, List, Sequence, Dict, Tuple
+from copy import deepcopy
+
+from .constants import (
+    PITCH_RANGE,
+    BEAT_RES,
+    NB_VELOCITIES,
+    SPECIAL_TOKENS,
+    USE_CHORDS,
+    USE_RESTS,
+    USE_TEMPOS,
+    USE_TIME_SIGNATURE,
+    USE_PROGRAMS,
+    REST_RANGE,
+    CHORD_MAPS,
+    CHORD_TOKENS_WITH_ROOT_NOTE,
+    CHORD_UNKNOWN,
+    NB_TEMPOS,
+    TEMPO_RANGE,
+    TIME_SIGNATURE_RANGE,
+    PROGRAMS,
+)
 
 
 @dataclass
@@ -83,3 +104,145 @@ class TokSequence:
                 common_attr = True
 
         return all(eq) if common_attr else False
+
+
+class TokenizerConfig:
+    r"""
+    MIDI tokenizer base class, containing common methods and attributes for all tokenizers.
+    :param pitch_range: (default: range(21, 109)) range of MIDI pitches to use. Pitches can take
+            values between 0 and 127 (included).
+            The `General MIDI 2 (GM2) specifications <https://www.midi.org/specifications-old/item/general-midi-2>`_
+            indicate the **recommended** ranges of pitches per MIDI program (instrument).
+            These recommended ranges can also be found in ``miditok.constants`` .
+            In all cases, the range from 21 to 108 (included) covers all the recommended values.
+            When processing a MIDI, the notes with pitches under or above this range can be discarded.
+    :param beat_res: (default: `{(0, 4): 8, (4, 12): 4}`) beat resolutions, as a dictionary in the form:
+            ``{(beat_x1, beat_x2): beat_res_1, (beat_x2, beat_x3): beat_res_2, ...}``
+            The keys are tuples indicating a range of beats, ex 0 to 3 for the first bar, and
+            the values are the resolution (in samples per beat) to apply to the ranges, ex 8.
+            This allows to use **Duration** / **TimeShift** tokens of different lengths / resolutions.
+            Note: for tokenization with **Position** tokens, the total number of possible positions will
+            be set at four times the maximum resolution given (``max(beat_res.values)``\).
+    :param nb_velocities: (default: 32) number of velocity bins. In the MIDI norm, velocities can take
+            up to 128 values (0 to 127). This parameter allows to reduce the number of velocity values.
+            The velocities of the MIDIs resolution will be downsampled to ``nb_velocities`` values, equally
+            separated between 0 and 127.
+    :param special_tokens: list of special tokens. This must be given as a list of strings given
+            only the names of the tokens. (default: ``["PAD", "BOS", "EOS", "MASK"]``\)
+    :param use_chords: will use ``Chord`` tokens, if the tokenizer is compatible. (default: False)
+    :param use_rests: will use ``Rest`` tokens, if the tokenizer is compatible. (default: False)
+    :param use_tempos: will use ``Tempo`` tokens, if the tokenizer is compatible. (default: False)
+    :param use_time_signatures: will use ``TimeSignature`` tokens, if the tokenizer is compatible. (default: False)
+    :param use_programs: will use ``Program`` tokens, if the tokenizer is compatible. (default: False)
+    :param rest_range: range of the rest to use, in beats, as a tuple (beat_division, max_rest_in_beats).
+            The beat division divides a beat to determine the minimum rest to represent.
+            The minimum rest must be divisible by 2 and lower than the first beat resolution
+    :param chord_maps: list of chord maps, to be given as a dictionary where keys are chord qualities
+            (e.g. "maj") and values pitch maps as tuples of integers (e.g. (0, 4, 7)).
+            You can use ``miditok.constants.CHORD_MAPS`` as an example.
+    :param chord_tokens_with_root_note: to specify the root note of each chord in ``Chord`` tokens.
+            Tokens will look as "Chord_C:maj". (default: False)
+    :param chord_unknown: range of number of notes to represent unknown chords.
+            If you want to represent chords that does not match any combination in ``chord_maps``, use this argument.
+            Leave ``None`` to not represent unknown chords. (default: None)
+    :param nb_tempos: number of tempos "bins" to use. (default: 32)
+    :param tempo_range: range of minimum and maximum tempos within which the bins fall. (default: (40, 250))
+    :param time_signature_range: TODO complete
+    :param programs: sequence of MIDI programs to use. Note that `-1` is used and reserved for drums tracks.
+            (default: from -1 to 127 included)
+    """
+
+    def __init__(
+        self,
+        pitch_range: Tuple[int, int] = PITCH_RANGE,
+        beat_res: Dict[Tuple[int, int], int] = BEAT_RES,
+        nb_velocities: int = NB_VELOCITIES,
+        special_tokens: Sequence[str] = SPECIAL_TOKENS,
+        use_chords: bool = USE_CHORDS,
+        use_rests: bool = USE_RESTS,
+        use_tempos: bool = USE_TEMPOS,
+        use_time_signatures: bool = USE_TIME_SIGNATURE,
+        use_programs: bool = USE_PROGRAMS,
+        rest_range: Sequence = REST_RANGE,
+        chord_maps: Dict[str, Tuple] = CHORD_MAPS,
+        chord_tokens_with_root_note: bool = CHORD_TOKENS_WITH_ROOT_NOTE,
+        chord_unknown: Tuple[int, int] = CHORD_UNKNOWN,
+        nb_tempos: int = NB_TEMPOS,
+        tempo_range: Tuple[int, int] = TEMPO_RANGE,
+        time_signature_range: Tuple[int, int] = TIME_SIGNATURE_RANGE,
+        programs: Sequence[int] = PROGRAMS,
+    ):
+        # Global parameters
+        self.pitch_range: Tuple[int, int] = pitch_range
+        self.beat_res: Dict[Tuple[int, int], int] = beat_res
+        self.nb_velocities: int = nb_velocities
+        self.special_tokens: Sequence[str] = special_tokens
+
+        # Additional token types params, enabling additional token types
+        self.use_chords: bool = use_chords
+        self.use_rests: bool = use_rests
+        self.use_tempos: bool = use_tempos
+        self.use_time_signatures: bool = use_time_signatures
+        self.use_programs: bool = use_programs
+
+        # Rest params
+        self.rest_range: Sequence = rest_range
+
+        # Chord params
+        self.chord_maps: Dict[str, Tuple] = chord_maps
+        self.chord_tokens_with_root_note: bool = (
+            chord_tokens_with_root_note  # Tokens will look as "Chord_C:maj"
+        )
+        self.chord_unknown: Tuple[
+            int, int
+        ] = chord_unknown  # (3, 6) for chords between 3 and 5 notes
+
+        # Tempo params
+        self.nb_tempos: int = nb_tempos  # nb of tempo bins for additional tempo tokens, quantized like velocities
+        self.tempo_range: Tuple[int, int] = tempo_range  # (min_tempo, max_tempo)
+
+        # Time signature params
+        self.time_signature_range: Tuple[int, int] = time_signature_range
+
+        # Programs
+        self.programs: Sequence[int] = programs
+
+    @classmethod
+    def from_dict(cls, input_dict: Dict[str, Any], **kwargs):
+        """
+        Instantiates an ``AdditionalTokensConfig`` from a Python dictionary of parameters.
+
+        :param input_dict: Dictionary that will be used to instantiate the configuration object.
+        :param kwargs: Additional parameters from which to initialize the configuration object.
+        :returns: ``AdditionalTokensConfig``: The configuration object instantiated from those parameters.
+        """
+        config = cls(**input_dict, **kwargs)
+        return config
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serializes this instance to a Python dictionary.
+
+        :return: Dictionary of all the attributes that make up this configuration instance.
+        """
+        return deepcopy(self.__dict__)
+
+    def __eq__(self, other):
+        # We don't use the == operator as it yields False when comparing lists and tuples containing the same elements
+        # Note: this is not recursive and only checks the first level of iterable values / attributes
+        other_dict = other.to_dict()
+        for key, value in self.to_dict().items():
+            if key not in other_dict:
+                return False
+
+            try:
+                if len(value) != len(other_dict[key]):
+                    return False
+                for val1, val2 in zip(value, other_dict[key]):
+                    if val1 != val2:
+                        return False
+            except TypeError:
+                if other_dict[key] != value:
+                    return False
+
+        return True

--- a/miditok/classes.py
+++ b/miditok/classes.py
@@ -171,7 +171,7 @@ class TokenizerConfig:
             Leave ``None`` to not represent unknown chords. (default: None)
     :param nb_tempos: number of tempos "bins" to use. (default: 32)
     :param tempo_range: range of minimum and maximum tempos within which the bins fall. (default: (40, 250))
-    :param time_signature_range: TODO complete
+    :param time_signature_range: range as a tuple (max_beat_res, nb_notes). (default: (8, 2))
     :param programs: sequence of MIDI programs to use. Note that `-1` is used and reserved for drums tracks.
             (default: from -1 to 127 included)
     :param **kwargs: additional parameters that will be saved in `config.additional_params`.

--- a/miditok/constants.py
+++ b/miditok/constants.py
@@ -2,7 +2,7 @@
 
 """
 
-CURRENT_VERSION_PACKAGE = "2.0.7"  # used when saving the config of a tokenizer
+CURRENT_VERSION_PACKAGE = "2.1.0"  # used when saving the config of a tokenizer
 
 MIDI_FILES_EXTENSIONS = [".mid", ".midi", ".MID", ".MIDI"]
 
@@ -12,6 +12,28 @@ MIDI_FILES_EXTENSIONS = [".mid", ".midi", ".MID", ".MIDI"]
 # List of unicode characters: https://www.fileformat.info/info/charset/UTF-8/list.htm
 CHR_ID_START = 33
 
+# MIDI encodings default parameters, used when tokenizing a dataset and using tokens
+# These are the parameters from which a MIDI file will be tokenized
+# the recommended pitches for piano in the GM2 specs are from 21 to 108
+PITCH_RANGE = (21, 109)
+BEAT_RES = {(0, 4): 8, (4, 12): 4}  # samples per beat
+# nb of velocity bins, velocities values from 0 to 127 will be quantized
+NB_VELOCITIES = 32
+# default special tokens
+SPECIAL_TOKENS = ["PAD", "BOS", "EOS", "MASK"]
+
+USE_CHORDS = False
+USE_RESTS = False
+USE_TEMPOS = False
+USE_TIME_SIGNATURE = False
+USE_PROGRAMS = False
+
+# rest params, (/min_rest, max_rest_in_BEAT)
+REST_RANGE = (2, 8)
+
+# Chord params
+# "chord_unknown" specifies the range of number of notes that can form "unknown" chords (that do not fit
+# in "chord_maps") to add in tokens
 # Known chord maps, with 0 as root note
 CHORD_MAPS = {
     "min": (0, 3, 7),
@@ -29,48 +51,28 @@ CHORD_MAPS = {
     "9maj": (0, 4, 7, 10, 14),
     "9min": (0, 4, 7, 10, 13),
 }
-UNKNOWN_CHORD_PREFIX = "ukn"
+# Tokens will look as "Chord_C:maj"
+CHORD_TOKENS_WITH_ROOT_NOTE = False
+# (3, 6) for chords between 3 and 5 notes
+CHORD_UNKNOWN = None
+UNKNOWN_CHORD_PREFIX = "ukn"  # only used in methods
 
-# MIDI encodings default parameters, used when tokenizing a dataset and using tokens
-# These are the parameters from which a MIDI file will be tokenized
-PITCH_RANGE = range(
-    21, 109
-)  # the recommended pitches for piano in the GM2 specs are from 21 to 108
-BEAT_RES = {(0, 4): 8, (4, 12): 4}  # samples per beat
-NB_VELOCITIES = (
-    32  # nb of velocity bins, velocities values from 0 to 127 will be quantized
-)
-ADDITIONAL_TOKENS = {
-    "Chord": False,
-    "Rest": False,
-    "Tempo": False,
-    "TimeSignature": False,
-    "Program": False,
-    # rest params
-    "rest_range": (
-        2,
-        8,
-    ),  # (/min_rest, max_rest_in_BEAT), first divides a whole note/rest
-    # Chord params
-    # "chord_unknown" specifies the range of number of notes that can form "unknown" chords (that do not fit
-    # in "chord_maps") to add in tokens
-    "chord_maps": CHORD_MAPS,
-    "chord_tokens_with_root_note": True,  # Tokens will look as "Chord_C:maj"
-    "chord_unknown": False,  # (3, 6) for chords between 3 and 5 notes
-    # Tempo params
-    "nb_tempos": 32,  # nb of tempo bins for additional tempo tokens, quantized like velocities
-    "tempo_range": (40, 250),  # (min_tempo, max_tempo)
-    # Time signature params
-    "time_signature_range": (8, 2),
-    # Programs
-    "programs": list(range(-1, 128)),
-}  # (max_beat_res, max_bar_length_in_NOTE)
-SPECIAL_TOKENS = ["PAD", "BOS", "EOS", "MASK"]  # default special tokens
+# Tempo params
+# nb of tempo bins for additional tempo tokens, quantized like velocities
+NB_TEMPOS = 32
+TEMPO_RANGE = (40, 250)  # (min_tempo, max_tempo)
+
+# Time signature params
+TIME_SIGNATURE_RANGE = (8, 2)
+
+# Programs
+PROGRAMS = list(range(-1, 128))
+
 
 # Tokenizers specific parameters
 # For MuMIDI, recommended range from the GM2 specs
 # note: we ignore the "Applause" at pitch 88 of the orchestra drum set, increase to 89 if you need it
-DRUM_PITCH_RANGE = range(27, 88)
+DRUM_PITCH_RANGE = (27, 88)
 MMM_DENSITY_BINS_MAX = (10, 20)
 
 # Defaults values when writing new MIDI files

--- a/miditok/data_augmentation/data_augmentation.py
+++ b/miditok/data_augmentation/data_augmentation.py
@@ -270,10 +270,11 @@ def get_offsets(
                     pitch_voc_idx, int(np.min(np.concatenate(ids_pitch)))
                 ].split("_")[1]
         offset_up = min(
-            nb_octave_offset, (tokenizer.pitch_range.stop - 1 - int(max_pitch)) // 12
+            nb_octave_offset,
+            (tokenizer.config.pitch_range[1] - 1 - int(max_pitch)) // 12,
         )
         offset_down = min(
-            nb_octave_offset, (int(min_pitch) - tokenizer.pitch_range.start) // 12
+            nb_octave_offset, (int(min_pitch) - tokenizer.config.pitch_range[0]) // 12
         )
 
         off = []

--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -15,7 +15,7 @@ from tokenizers import Tokenizer as TokenizerFast
 from tokenizers.models import BPE
 from tokenizers.trainers import BpeTrainer
 
-from .classes import Event, TokSequence
+from .classes import Event, TokSequence, TokenizerConfig
 from .utils import (
     remove_duplicated_notes,
     get_midi_programs,
@@ -25,11 +25,6 @@ from .data_augmentation import data_augmentation_dataset
 from .constants import (
     TIME_DIVISION,
     CURRENT_VERSION_PACKAGE,
-    PITCH_RANGE,
-    BEAT_RES,
-    NB_VELOCITIES,
-    ADDITIONAL_TOKENS,
-    SPECIAL_TOKENS,
     CHR_ID_START,
     PITCH_CLASSES,
     UNKNOWN_CHORD_PREFIX,
@@ -97,29 +92,7 @@ def _out_as_complete_seq(function: Callable):
 class MIDITokenizer(ABC):
     r"""MIDI tokenizer base class, containing common methods and attributes for all tokenizers.
 
-    :param pitch_range: (default: range(21, 109)) range of MIDI pitches to use. Pitches can take
-            values between 0 and 127 (included).
-            The `General MIDI 2 (GM2) specifications <https://www.midi.org/specifications-old/item/general-midi-2>`_
-            indicate the **recommended** ranges of pitches per MIDI program (instrument).
-            These recommended ranges can also be found in ``miditok.constants`` .
-            In all cases, the range from 21 to 108 (included) covers all the recommended values.
-            When processing a MIDI, the notes with pitches under or above this range can be discarded.
-    :param beat_res: (default: `{(0, 4): 8, (4, 12): 4}`) beat resolutions, as a dictionary in the form:
-            ``{(beat_x1, beat_x2): beat_res_1, (beat_x2, beat_x3): beat_res_2, ...}``
-            The keys are tuples indicating a range of beats, ex 0 to 3 for the first bar, and
-            the values are the resolution (in samples per beat) to apply to the ranges, ex 8.
-            This allows to use **Duration** / **TimeShift** tokens of different lengths / resolutions.
-            Note: for tokenization with **Position** tokens, the total number of possible positions will
-            be set at four times the maximum resolution given (``max(beat_res.values)``\).
-    :param nb_velocities: (default: 32) number of velocity bins. In the MIDI norm, velocities can take
-            up to 128 values (0 to 127). This parameter allows to reduce the number of velocity values.
-            The velocities of the MIDIs resolution will be downsampled to ``nb_velocities`` values, equally
-            separated between 0 and 127.
-    :param additional_tokens: (default: None used) specify which additional tokens to use.
-            Compatibilities between tokenization and additional tokens may vary.
-            See :ref:`Additional tokens` for the details and available tokens.
-    :param special_tokens: list of special tokens. This must be given as a list of strings given
-            only the names of the tokens. (default: ``["PAD", "BOS", "EOS", "MASK"]``\)
+    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
     :param unique_track: set to True if the tokenizer works only with a unique track.
             Tokens will be saved as a single track. This applies to representations that natively handle
             multiple tracks such as Octuple, resulting in a single "stream" of tokens for all tracks.
@@ -131,83 +104,79 @@ class MIDITokenizer(ABC):
 
     def __init__(
         self,
-        pitch_range: range = PITCH_RANGE,
-        beat_res: Dict[Tuple[int, int], int] = BEAT_RES,
-        nb_velocities: int = NB_VELOCITIES,
-        additional_tokens: Dict[
-            str, Union[bool, int, Dict[str, Tuple], Tuple[int, int]]
-        ] = ADDITIONAL_TOKENS,
-        special_tokens: List[str] = SPECIAL_TOKENS,
+        tokenizer_config: TokenizerConfig = None,
         unique_track: bool = False,
         params: Union[str, Path] = None,
     ):
         # Initialize params
-        self._vocab_base = (
-            {}
-        )  # vocab of prime tokens, can be viewed as unique char / bytes
-        self.__vocab_base_inv = {}  # the other way, to decode id (int) -> token (str)
-        self._vocab_base_id_to_byte = (
-            {}
-        )  # id (int) -> byte (str), as this might not be chr(id) after BPE training
-        self._vocab_base_byte_to_token = (
-            {}
-        )  # byte (str) -> token (str), for basic tokens
-        self._vocab_bpe_bytes_to_tokens = (
-            {}
-        )  # byte(s) -> token(s), for faster BPE decoding
+        self.config = deepcopy(tokenizer_config)
+        # vocab of prime tokens, can be viewed as unique char / bytes
+        self._vocab_base = {}
+        # the other way, to decode id (int) -> token (str)
+        self.__vocab_base_inv = {}
+        # id (int) -> byte (str), as this might not be chr(id) after BPE training
+        self._vocab_base_id_to_byte = {}
+        # byte (str) -> token (str), for basic tokens
+        self._vocab_base_byte_to_token = {}
+        # byte(s) -> token(s), for faster BPE decoding
+        self._vocab_bpe_bytes_to_tokens = {}
         self.has_bpe = False
-
         # Fast BPE tokenizer backed with 🤗tokenizers
         self._bpe_model = None
 
         # Loading params, or initializing them from args
         if params is not None:
+            # Will overwrite self.config
             self._load_params(params)
         else:
+            assert self.config is not None, (
+                "You must specify either a tokenizer_config (TokenizerConfig object)"
+                "or the path to a saved configuration (params argument)"
+            )
             assert (
-                pitch_range.start >= 0 and pitch_range.stop <= 128
+                self.config.pitch_range[0] >= 0 and self.config.pitch_range[1] <= 128
             ), "You must specify a pitch_range between 0 and 127 (included, i.e. range.stop at 128)"
             assert (
-                0 < nb_velocities < 128
+                0 < self.config.nb_velocities < 128
             ), "You must specify a nb_velocities between 1 and 127 (included)"
-            self.pitch_range = pitch_range
-            self.beat_res = beat_res
-            self._nb_velocities = nb_velocities
-            self.additional_tokens = additional_tokens
-            self.special_tokens = special_tokens if special_tokens is not None else []
             self.unique_track = unique_track
+
+        # Tweak the tokenizer's configuration and / or attributes before creating the vocabulary
+        # This method is intended to be overridden by inheriting tokenizer classes
+        self._tweak_config_before_creating_voc()
 
         # Init duration and velocity values
         self.durations = self.__create_durations_tuples()
-        self.velocities = np.linspace(0, 127, self._nb_velocities + 1, dtype=np.intc)[
-            1:
-        ]  # remove velocity 0
-        self._first_beat_res = list(self.beat_res.values())[0]
-        for beat_range, res in self.beat_res.items():
+        # [1:] so that there is no velocity_0
+        self.velocities = np.linspace(
+            0, 127, self.config.nb_velocities + 1, dtype=np.intc
+        )[1:]
+        self._first_beat_res = list(self.config.beat_res.values())[0]
+        for beat_range, res in self.config.beat_res.items():
             if 0 in beat_range:
                 self._first_beat_res = res
                 break
 
         # Tempos
         self.tempos = np.zeros(1)
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             self.tempos = np.linspace(
-                *self.additional_tokens["tempo_range"],
-                self.additional_tokens["nb_tempos"],
+                *self.config.tempo_range,
+                self.config.nb_tempos,
                 dtype=np.intc,
             )
 
         # Rests
         self.rests = []
-        if self.additional_tokens["Rest"]:
+        if self.config.use_rests:
             assert (
-                self.additional_tokens["rest_range"][0] // 4 <= self._first_beat_res
+                self.config.rest_range[0] // 4 <= self._first_beat_res
             ), "The minimum rest value must be equal or superior to the initial beat resolution"
             self.rests = self.__create_rests()
 
         # Time Signatures
         self.time_signatures = []
-        if self.additional_tokens["TimeSignature"]:
+        if self.config.use_time_signatures:
             self.time_signatures = self.__create_time_signatures()
 
         # Vocabulary and token types graph
@@ -227,6 +196,10 @@ class MIDITokenizer(ABC):
         # Holds the tempo changes, time signature, time division and key signature of a
         # MIDI (being parsed) so that methods processing tracks can access them
         self._current_midi_metadata = {}  # needs to be updated each time a MIDI is read
+
+    def _tweak_config_before_creating_voc(self):
+        # called after setting the tokenizer's TokenizerConfig (.config). To be customized by tokenizer classes.
+        pass
 
     @property
     def vocab(
@@ -296,14 +269,14 @@ class MIDITokenizer(ABC):
                 [max([note.end for note in track.notes]) for track in midi.instruments]
             )
 
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             self._quantize_tempos(midi.tempo_changes, midi.ticks_per_beat)
 
         if len(midi.time_signature_changes) == 0:  # can sometimes happen
             midi.time_signature_changes.append(
                 TimeSignature(4, 4, 0)
             )  # 4/4 by default in this case
-        if self.additional_tokens["TimeSignature"]:
+        if self.config.use_time_signatures:
             self._quantize_time_signatures(
                 midi.time_signature_changes, midi.ticks_per_beat
             )
@@ -317,10 +290,11 @@ class MIDITokenizer(ABC):
         :param notes: notes to quantize.
         :param time_division: MIDI time division / resolution, in ticks/beat (of the MIDI being parsed).
         """
-        ticks_per_sample = int(time_division / max(self.beat_res.values()))
+        ticks_per_sample = int(time_division / max(self.config.beat_res.values()))
         i = 0
+        pitches = range(*self.config.pitch_range)
         while i < len(notes):
-            if notes[i].pitch not in self.pitch_range:
+            if notes[i].pitch not in pitches:
                 del notes[i]
                 continue
             start_offset = notes[i].start % ticks_per_sample
@@ -359,7 +333,7 @@ class MIDITokenizer(ABC):
         :param tempos: tempo changes to quantize.
         :param time_division: MIDI time division / resolution, in ticks/beat (of the MIDI being parsed).
         """
-        ticks_per_sample = int(time_division / max(self.beat_res.values()))
+        ticks_per_sample = int(time_division / max(self.config.beat_res.values()))
         prev_tempo = -1
         i = 0
         while i < len(tempos):
@@ -675,7 +649,7 @@ class MIDITokenizer(ABC):
         This method is called at ``__init__``\.
         """
         vocab = self._create_base_vocabulary()
-        special_tokens = [f"{tok}_None" for tok in self.special_tokens]
+        special_tokens = [f"{tok}_None" for tok in self.config.special_tokens]
 
         if isinstance(vocab[0], list):  # multi-voc
             self._vocab_base = [{} for _ in range(len(vocab))]
@@ -748,11 +722,7 @@ class MIDITokenizer(ABC):
                 len(self.__vocab_base_inv[vocab_idx])
             ] = token_str
         else:
-            id_ = (
-                len(self._bpe_model.get_vocab())
-                if self.has_bpe
-                else len(self.vocab)
-            )
+            id_ = len(self._bpe_model.get_vocab()) if self.has_bpe else len(self.vocab)
             self._vocab_base[token_str] = id_
             self.__vocab_base_inv[len(self.__vocab_base_inv)] = token_str
 
@@ -773,31 +743,27 @@ class MIDITokenizer(ABC):
         :return: chord tokens, created from the tokenizer's params
         """
         tokens = []
-        if self.additional_tokens.get("chord_tokens_with_root_note", False):
+        if self.config.chord_tokens_with_root_note:
             tokens += [
                 f"Chord_{root_note}:{chord_quality}"
-                for chord_quality in self.additional_tokens["chord_maps"]
+                for chord_quality in self.config.chord_maps
                 for root_note in PITCH_CLASSES
             ]
         else:
             tokens += [
-                f"Chord_{chord_quality}"
-                for chord_quality in self.additional_tokens["chord_maps"]
+                f"Chord_{chord_quality}" for chord_quality in self.config.chord_maps
             ]
 
         # Unknown chords
-        if self.additional_tokens["chord_unknown"] is not False:
-            if self.additional_tokens["chord_tokens_with_root_note"]:
+        if self.config.chord_unknown is not None:
+            if self.config.chord_tokens_with_root_note:
                 tokens += [
                     f"Chord_{root_note}:{UNKNOWN_CHORD_PREFIX}{i}"
-                    for i in range(*self.additional_tokens["chord_unknown"])
+                    for i in range(*self.config.chord_unknown)
                     for root_note in PITCH_CLASSES
                 ]
             else:
-                tokens += [
-                    f"Chord_{i}"
-                    for i in range(*self.additional_tokens["chord_unknown"])
-                ]
+                tokens += [f"Chord_{i}" for i in range(*self.config.chord_unknown)]
 
         return tokens
 
@@ -825,12 +791,12 @@ class MIDITokenizer(ABC):
         No token type can precede a BOS token, and EOS token cannot precede any other token.
         """
         original_token_types = list(self.tokens_types_graph.keys())
-        for special_token in self.special_tokens:
+        for special_token in self.config.special_tokens:
             if special_token == "EOS":
                 self.tokens_types_graph["EOS"] = []
             else:
-                self.tokens_types_graph[special_token] = (
-                    original_token_types + self.special_tokens
+                self.tokens_types_graph[special_token] = original_token_types + list(
+                    self.config.special_tokens
                 )
 
             if special_token != "BOS":
@@ -849,14 +815,18 @@ class MIDITokenizer(ABC):
         :return: the duration bins.
         """
         durations = []
-        for beat_range, beat_res in self.beat_res.items():
+        for beat_range, beat_res in self.config.beat_res.items():
             durations += [
                 (beat, pos, beat_res)
                 for beat in range(*beat_range)
                 for pos in range(beat_res)
             ]
         durations += [
-            (max(max(self.beat_res)), 0, self.beat_res[max(self.beat_res)])
+            (
+                max(max(self.config.beat_res)),
+                0,
+                self.config.beat_res[max(self.config.beat_res)],
+            )
         ]  # the last one
         del durations[0]  # removes duration of 0
         return durations
@@ -876,8 +846,8 @@ class MIDITokenizer(ABC):
     def __create_rests(self) -> List[Tuple]:
         r"""Creates the possible rests in beat / position units, as tuple of the form:
         (beat, pos) where beat is the number of beats, pos the number of "samples"
-        The rests are calculated from the value of self.additional_tokens[rest_range],
-        which first value divide a beat to determine the minimum rest represented,
+        The rests are calculated from the value of self.config.rest_range,
+        which first value divides a beat to determine the minimum rest to represent,
         and the second the maximum rest in beats.
         The rests shorter than 1 beat will scale x2, as rests in music theory (semiquaver, quaver, crotchet...)
         Note that the values of the rests in positions will be determined by the beat
@@ -888,7 +858,7 @@ class MIDITokenizer(ABC):
 
         :return: the rests.
         """
-        div, max_beat = self.additional_tokens["rest_range"]
+        div, max_beat = self.config.rest_range
         assert (
             div % 2 == 0 and div <= self._first_beat_res
         ), f"The minimum rest must be divisible by 2 and lower than the first beat resolution ({self._first_beat_res})"
@@ -900,15 +870,14 @@ class MIDITokenizer(ABC):
         return rests
 
     def __create_time_signatures(self) -> List[Tuple]:
-        r"""Creates the possible time signatures, as tuple of the form:
+        r"""Creates the possible time signatures, as tuples of the form:
         (nb_beats, beat_res) where nb_beats is the number of beats per bar.
         Example: (3, 4) means one bar is 3 beat long and each beat is a quarter note.
+        # TODO clarify this, use only denominator
 
         :return: the time signatures.
         """
-        max_beat_res, nb_notes = self.additional_tokens.get(
-            "time_signature_range", (4, 1)
-        )
+        max_beat_res, nb_notes = self.config.time_signature_range
         assert (
             max_beat_res > 0 and math.log2(max_beat_res).is_integer()
         ), "The beat resolution in time signature must be a power of 2"
@@ -934,7 +903,7 @@ class MIDITokenizer(ABC):
         :param denominator: time signature's denominator (beat resolution).
         :return: the numerator and denominator of a reduced and decomposed time signature.
         """
-        max_beat_res, nb_notes = self.additional_tokens["time_signature_range"]
+        max_beat_res, nb_notes = self.config.time_signature_range
 
         # reduction (when denominator exceed max_beat_res)
         while (
@@ -1059,7 +1028,7 @@ class MIDITokenizer(ABC):
         # Create new tokenizer model
         if self._bpe_model is None or start_from_empty_voc:
             nb_bytes = (
-                len(self.special_tokens)
+                len(self.config.special_tokens)
                 if start_from_empty_voc
                 else len(self._vocab_base)
             )
@@ -1077,7 +1046,7 @@ class MIDITokenizer(ABC):
 
         # Trains the tokenizer
         special_tokens_bytes = self._ids_to_bytes(
-            self._tokens_to_ids([f"{tok}_None" for tok in self.special_tokens])
+            self._tokens_to_ids([f"{tok}_None" for tok in self.config.special_tokens])
         )
         trainer = BpeTrainer(
             vocab_size=vocab_size,
@@ -1151,31 +1120,6 @@ class MIDITokenizer(ABC):
             encoded_tokens = self._bpe_model.encode([seq.bytes], is_pretokenized=True)
             seq.ids = encoded_tokens.ids
             seq.ids_bpe_encoded = True
-
-    @staticmethod
-    def __find_subseq(in_list: List[int], pattern: List[int]) -> List[int]:
-        """Finds the locations of a pattern within a list.
-        Adapted from: https://stackoverflow.com/questions/10106901/elegant-find-sub-list-in-list
-        Related: https://www.reddit.com/r/learnpython/comments/2xqlwj/using_npwhere_to_find_subarrays/
-        After testing, the numba jit version does not seem to be much faster.
-        The conversion of python lists to numba.typed.List() seems to also take time.
-
-        :param in_list: input list to analyze.
-        :param pattern: pattern to detect.
-        :return: indices of in_list where the pattern has been found.
-        """
-        matches = []
-        next_possible_idx = 0
-        for i in range(len(in_list)):
-            if (
-                in_list[i] == pattern[0]
-                and in_list[i : i + len(pattern)] == pattern
-                and i >= next_possible_idx
-            ):
-                matches.append(i)
-                next_possible_idx = i + len(pattern)
-
-        return matches
 
     def apply_bpe_to_dataset(
         self, dataset_path: Union[Path, str], out_path: Union[Path, str] = None
@@ -1296,7 +1240,7 @@ class MIDITokenizer(ABC):
                 continue
 
             # Checks the time division is valid
-            if midi.ticks_per_beat < max(self.beat_res.values()) * 4:
+            if midi.ticks_per_beat < max(self.config.beat_res.values()) * 4:
                 continue
             # Passing the MIDI to validation tests if given
             if validation_fn is not None:
@@ -1462,14 +1406,16 @@ class MIDITokenizer(ABC):
         if self.has_bpe:  # saves whole vocab if BPE
             additional_attributes["_vocab_base"] = self._vocab_base
             additional_attributes["_bpe_model"] = self._bpe_model.to_str()
-            additional_attributes["_vocab_base_byte_to_token"] = self._vocab_base_byte_to_token
+            additional_attributes[
+                "_vocab_base_byte_to_token"
+            ] = self._vocab_base_byte_to_token
 
+        dict_config = self.config.to_dict()
+        dict_config["beat_res"] = {
+            f"{k1}_{k2}": v for (k1, k2), v in dict_config["beat_res"].items()
+        }
         params = {
-            "pitch_range": (self.pitch_range.start, self.pitch_range.stop),
-            "beat_res": {f"{k1}_{k2}": v for (k1, k2), v in self.beat_res.items()},
-            "_nb_velocities": len(self.velocities),
-            "additional_tokens": self.additional_tokens,
-            "special_tokens": self.special_tokens,
+            "config": dict_config,
             "unique_track": self.unique_track,
             "has_bpe": self.has_bpe,
             "tokenization": self.__class__.__name__,
@@ -1491,26 +1437,28 @@ class MIDITokenizer(ABC):
         with open(config_file_path) as param_file:
             params = json.load(param_file)
 
-        params["pitch_range"] = range(*params["pitch_range"])
+        # Grab config, or creates one with default parameters (for retro-compatibility with previous version)
+        self.config = TokenizerConfig()
+        config_attributes = list(self.config.to_dict().keys())
+        old_add_tokens_attr = {
+            "Chord": "use_chords",
+            "Rest": "use_rests",
+            "Tempo": "use_tempos",
+            "TimeSignature": "use_time_signatures",
+            "Program": "use_program",
+        }
 
+        # Overwrite config attributes
         for key, value in params.items():
             if key in ["tokenization", "miditok_version"]:
                 continue
-            elif key == "beat_res":
-                value = {
-                    tuple(map(int, beat_range.split("_"))): res
-                    for beat_range, res in value.items()
-                }
-            elif key == "additional_tokens":
-                value["TimeSignature"] = value.get("TimeSignature", False)
             elif key == "_vocab_base":
                 self._vocab_base = value
                 self.__vocab_base_inv = {v: k for k, v in value.items()}
                 continue
             elif key == "_bpe_model":
-                self._bpe_model = TokenizerFast.from_str(
-                    value
-                )  # using 🤗tokenizers builtin method
+                # using 🤗tokenizers builtin method
+                self._bpe_model = TokenizerFast.from_str(value)
                 continue
             elif key == "_vocab_base_byte_to_token":
                 self._vocab_base_byte_to_token = value
@@ -1522,6 +1470,23 @@ class MIDITokenizer(ABC):
                     k: [self._vocab_base_byte_to_token[b] for b in k]
                     for k in self._bpe_model.get_vocab()
                 }
+                continue
+            elif key == "config":
+                value["beat_res"] = {
+                    tuple(map(int, beat_range.split("_"))): res
+                    for beat_range, res in value["beat_res"].items()
+                }
+                value = TokenizerConfig.from_dict(value)
+            elif key in config_attributes:
+                if key == "beat_res":
+                    value = {
+                        tuple(map(int, beat_range.split("_"))): res
+                        for beat_range, res in value.items()
+                    }
+                # Convert old attribute from < v2.1.0 to new for TokenizerConfig
+                elif key in old_add_tokens_attr:
+                    key = old_add_tokens_attr[key]
+                setattr(self.config, key, value)
                 continue
 
             setattr(self, key, value)
@@ -1646,7 +1611,7 @@ class MIDITokenizer(ABC):
 
     def __eq__(self, other) -> bool:
         r"""Checks if two tokenizers are identical. This is done by comparing their vocabularies,
-        as they are built depending on most of their attributes.
+        and configuration.
 
         :param other: tokenizer to compare.
         :return: True if the vocabulary(ies) are identical, False otherwise.
@@ -1659,5 +1624,6 @@ class MIDITokenizer(ABC):
                 self._vocab_base == other._vocab_base
                 and bpe_voc_eq
                 and self._vocab_base_byte_to_token == other._vocab_base_byte_to_token
+                and self.config == other.config
             )
         return False

--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -890,7 +890,6 @@ class MIDITokenizer(ABC):
         r"""Creates the possible time signatures, as tuples of the form:
         (nb_beats, beat_res) where nb_beats is the number of beats per bar.
         Example: (3, 4) means one bar is 3 beat long and each beat is a quarter note.
-        # TODO clarify this, use only denominator
 
         :return: the time signatures.
         """

--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -1426,7 +1426,7 @@ class MIDITokenizer(ABC):
                 "_vocab_base_byte_to_token"
             ] = self._vocab_base_byte_to_token
 
-        dict_config = self.config.to_dict()
+        dict_config = self.config.to_dict(serialize=True)
         dict_config["beat_res"] = {
             f"{k1}_{k2}": v for (k1, k2), v in dict_config["beat_res"].items()
         }

--- a/miditok/tokenizations/cp_word.py
+++ b/miditok/tokenizations/cp_word.py
@@ -5,18 +5,9 @@ import numpy as np
 from miditoolkit import Instrument, Note, TempoChange
 
 from ..midi_tokenizer import MIDITokenizer, _in_as_seq, _out_as_complete_seq
-from ..classes import TokSequence, Event
+from ..classes import TokSequence, Event, TokenizerConfig
 from ..utils import detect_chords
-from ..constants import (
-    PITCH_RANGE,
-    NB_VELOCITIES,
-    BEAT_RES,
-    ADDITIONAL_TOKENS,
-    SPECIAL_TOKENS,
-    TIME_DIVISION,
-    TEMPO,
-    MIDI_INSTRUMENTS,
-)
+from ..constants import TIME_DIVISION, TEMPO, MIDI_INSTRUMENTS
 
 
 class CPWord(MIDITokenizer):
@@ -41,50 +32,32 @@ class CPWord(MIDITokenizer):
     For generation, the decoding implies sample from several distributions, which can be
     very delicate. Hence, we do not recommend this tokenization for generation with small models.
 
-    :param pitch_range: range of MIDI pitches to use
-    :param beat_res: beat resolutions, as a dictionary:
-            {(beat_x1, beat_x2): beat_res_1, (beat_x2, beat_x3): beat_res_2, ...}
-            The keys are tuples indicating a range of beats, ex 0 to 3 for the first bar, and
-            the values are the resolution to apply to the ranges, in samples per beat, ex 8
-    :param nb_velocities: number of velocity bins
-    :param additional_tokens: additional tokens (chords, time signature, rests, tempo...) to use,
-            to be given as a dictionary. (default: None is used)
-    :param special_tokens: list of special tokens. This must be given as a list of strings given
-            only the names of the tokens. (default: ``["PAD", "BOS", "EOS", "MASK"]``)
+    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
     :param params: path to a tokenizer config file. This will override other arguments and
             load the tokenizer based on the config file. This is particularly useful if the
             tokenizer learned Byte Pair Encoding. (default: None)
     """
 
     def __init__(
-        self,
-        pitch_range: range = PITCH_RANGE,
-        beat_res: Dict[Tuple[int, int], int] = BEAT_RES,
-        nb_velocities: int = NB_VELOCITIES,
-        additional_tokens: Dict[str, bool] = ADDITIONAL_TOKENS,
-        special_tokens: List[str] = SPECIAL_TOKENS,
-        params: Union[str, Path] = None,
+        self, tokenizer_config: TokenizerConfig = None, params: Union[str, Path] = None
     ):
-        # Indexes of additional token types within a compound token
-        additional_tokens["TimeSignature"] = False  # not compatible
+        super().__init__(tokenizer_config, False, params)
+
+    def _tweak_config_before_creating_voc(self):
+        self.config.use_time_signatures = False
         token_types = ["Family", "Position", "Pitch", "Velocity", "Duration"]
-        add_tokens = ["Program", "Chord", "Rest", "Tempo"]
-        for add_token in add_tokens:
-            if additional_tokens[add_token]:
+        for add_tok_attr, add_token in [
+            ("use_programs", "Program"),
+            ("use_chords", "Chord"),
+            ("use_rests", "Rest"),
+            ("use_tempos", "Tempo"),
+        ]:
+            if getattr(self.config, add_tok_attr):
                 token_types.append(add_token)
         self.vocab_types_idx = {
             type_: idx for idx, type_ in enumerate(token_types)
         }  # used for data augmentation
         self.vocab_types_idx["Bar"] = 1  # same as position
-
-        super().__init__(
-            pitch_range,
-            beat_res,
-            nb_velocities,
-            additional_tokens,
-            special_tokens,
-            params=params,
-        )
 
     @_out_as_complete_seq
     def track_to_tokens(self, track: Instrument) -> TokSequence:
@@ -96,14 +69,14 @@ class CPWord(MIDITokenizer):
         # Make sure the notes are sorted first by their onset (start) times, second by pitch
         # notes.sort(key=lambda x: (x.start, x.pitch))  # done in midi_to_tokens
         ticks_per_sample = self._current_midi_metadata["time_division"] / max(
-            self.beat_res.values()
+            self.config.beat_res.values()
         )
         ticks_per_bar = self._current_midi_metadata["time_division"] * 4
         dur_bins = self._durations_ticks[self._current_midi_metadata["time_division"]]
         min_rest = (
             self._current_midi_metadata["time_division"] * self.rests[0][0]
             + ticks_per_sample * self.rests[0][1]
-            if self.additional_tokens["Rest"]
+            if self.config.use_rests
             else 0
         )
         tokens: List[List[Union[str, Event]]] = []  # list of lists of tokens
@@ -123,7 +96,7 @@ class CPWord(MIDITokenizer):
             if note.start != previous_tick:
                 # (Rest)
                 if (
-                    self.additional_tokens["Rest"]
+                    self.config.use_rests
                     and note.start > previous_note_end
                     and note.start - previous_note_end >= min_rest
                 ):
@@ -162,7 +135,7 @@ class CPWord(MIDITokenizer):
                     current_bar = previous_tick // ticks_per_bar
 
                 # (Tempo)
-                if self.additional_tokens["Tempo"]:
+                if self.config.use_tempos:
                     # If the current tempo is not the last one
                     if current_tempo_idx + 1 < len(
                         self._current_midi_metadata["tempo_changes"]
@@ -196,9 +169,7 @@ class CPWord(MIDITokenizer):
                     self.__create_cp_token(
                         int(note.start),
                         pos=pos_index,
-                        tempo=current_tempo
-                        if self.additional_tokens["Tempo"]
-                        else None,
+                        tempo=current_tempo if self.config.use_tempos else None,
                         desc="Position",
                     )
                 )
@@ -222,14 +193,14 @@ class CPWord(MIDITokenizer):
         tokens.sort(key=lambda x: x[0].time)
 
         # Adds chord tokens if specified
-        if self.additional_tokens["Chord"] and not track.is_drum:
+        if self.config.use_chords and not track.is_drum:
             chord_events = detect_chords(
                 track.notes,
                 self._current_midi_metadata["time_division"],
-                chord_maps=self.additional_tokens["chord_maps"],
-                specify_root_note=self.additional_tokens["chord_tokens_with_root_note"],
+                chord_maps=self.config.chord_maps,
+                specify_root_note=self.config.chord_tokens_with_root_note,
                 beat_res=self._first_beat_res,
-                unknown_chords_nb_notes_range=self.additional_tokens["chord_unknown"],
+                unknown_chords_nb_notes_range=self.config.chord_unknown,
             )
             count = 0
             for chord_event in chord_events:
@@ -299,8 +270,8 @@ class CPWord(MIDITokenizer):
             "Ignore_None",
             "Ignore_None",
         ]
-        for add_tok in ["Program", "Chord", "Rest", "Tempo"]:
-            if self.additional_tokens[add_tok]:
+        for add_tok_attr in ["use_programs", "use_chords", "use_rests", "use_tempos"]:
+            if getattr(self.config, add_tok_attr):
                 cp_token_template.append("Ignore_None")
 
         if bar:
@@ -341,10 +312,10 @@ class CPWord(MIDITokenizer):
         :return: the miditoolkit instrument object and tempo changes
         """
         assert (
-            time_division % max(self.beat_res.values()) == 0
-        ), f"Invalid time division, please give one divisible by {max(self.beat_res.values())}"
+            time_division % max(self.config.beat_res.values()) == 0
+        ), f"Invalid time division, please give one divisible by {max(self.config.beat_res.values())}"
 
-        ticks_per_sample = time_division // max(self.beat_res.values())
+        ticks_per_sample = time_division // max(self.config.beat_res.values())
         ticks_per_bar = time_division * 4
         name = "Drums" if program[1] else MIDI_INSTRUMENTS[program[0]]["name"]
         instrument = Instrument(program[0], is_drum=program[1], name=name)
@@ -384,12 +355,12 @@ class CPWord(MIDITokenizer):
                         current_bar * ticks_per_bar
                         + int(compound_token[1].split("_")[1]) * ticks_per_sample
                     )
-                    if self.additional_tokens["Tempo"]:
+                    if self.config.use_tempos:
                         tempo = int(compound_token[-1].split("_")[1])
                         if tempo != tempo_changes[-1].tempo:
                             tempo_changes.append(TempoChange(tempo, current_tick))
                 elif (
-                    self.additional_tokens["Rest"]
+                    self.config.use_rests
                     and compound_token[self.vocab_types_idx["Rest"]].split("_")[1]
                     != "None"
                 ):
@@ -428,14 +399,14 @@ class CPWord(MIDITokenizer):
         vocab[0].append("Family_Note")
 
         # POSITION
-        nb_positions = max(self.beat_res.values()) * 4  # 4/* time signature
+        nb_positions = max(self.config.beat_res.values()) * 4  # 4/* time signature
         vocab[1].append("Ignore_None")
         vocab[1].append("Bar_None")
         vocab[1] += [f"Position_{i}" for i in range(nb_positions)]
 
         # PITCH
         vocab[2].append("Ignore_None")
-        vocab[2] += [f"Pitch_{i}" for i in self.pitch_range]
+        vocab[2] += [f"Pitch_{i}" for i in range(*self.config.pitch_range)]
 
         # VELOCITY
         vocab[3].append("Ignore_None")
@@ -448,24 +419,24 @@ class CPWord(MIDITokenizer):
         ]
 
         # PROGRAM
-        if self.additional_tokens["Program"]:
+        if self.config.use_programs:
             vocab += [
                 ["Ignore_None"] + [f"Program_{program}" for program in range(-1, 128)]
             ]
 
         # CHORD
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             vocab += [["Ignore_None"] + self._create_chords_tokens()]
 
         # REST
-        if self.additional_tokens["Rest"]:
+        if self.config.use_rests:
             vocab += [
                 ["Ignore_None"]
                 + [f'Rest_{".".join(map(str, rest))}' for rest in self.rests]
             ]
 
         # TEMPO
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             vocab += [["Ignore_None"] + [f"Tempo_{i}" for i in self.tempos]]
 
         return vocab
@@ -489,11 +460,11 @@ class CPWord(MIDITokenizer):
         dic["Position"] = ["Pitch"]
         dic["Pitch"] = ["Pitch", "Bar", "Position"]
 
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             dic["Rest"] = ["Rest", "Position"]
             dic["Pitch"] += ["Rest"]
 
-        if self.additional_tokens["Rest"]:
+        if self.config.use_rests:
             dic["Rest"] = ["Rest", "Position", "Bar"]
             dic["Pitch"] += ["Rest"]
 

--- a/miditok/tokenizations/cp_word.py
+++ b/miditok/tokenizations/cp_word.py
@@ -1,11 +1,10 @@
 from typing import List, Tuple, Dict, Optional, Union, Any
-from pathlib import Path
 
 import numpy as np
 from miditoolkit import Instrument, Note, TempoChange
 
 from ..midi_tokenizer import MIDITokenizer, _in_as_seq, _out_as_complete_seq
-from ..classes import TokSequence, Event, TokenizerConfig
+from ..classes import TokSequence, Event
 from ..utils import detect_chords
 from ..constants import TIME_DIVISION, TEMPO, MIDI_INSTRUMENTS
 
@@ -31,17 +30,7 @@ class CPWord(MIDITokenizer):
     (one per token type). This means that the training requires to add multiple losses.
     For generation, the decoding implies sample from several distributions, which can be
     very delicate. Hence, we do not recommend this tokenization for generation with small models.
-
-    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
-    :param params: path to a tokenizer config file. This will override other arguments and
-            load the tokenizer based on the config file. This is particularly useful if the
-            tokenizer learned Byte Pair Encoding. (default: None)
     """
-
-    def __init__(
-        self, tokenizer_config: TokenizerConfig = None, params: Union[str, Path] = None
-    ):
-        super().__init__(tokenizer_config, False, params)
 
     def _tweak_config_before_creating_voc(self):
         self.config.use_time_signatures = False

--- a/miditok/tokenizations/midi_like.py
+++ b/miditok/tokenizations/midi_like.py
@@ -5,14 +5,9 @@ import numpy as np
 from miditoolkit import Instrument, Note, TempoChange
 
 from ..midi_tokenizer import MIDITokenizer, _in_as_seq, _out_as_complete_seq
-from ..classes import TokSequence, Event
+from ..classes import TokSequence, Event, TokenizerConfig
 from ..utils import detect_chords
 from ..constants import (
-    PITCH_RANGE,
-    NB_VELOCITIES,
-    BEAT_RES,
-    ADDITIONAL_TOKENS,
-    SPECIAL_TOKENS,
     TIME_DIVISION,
     TEMPO,
     MIDI_INSTRUMENTS,
@@ -29,39 +24,19 @@ class MIDILike(MIDITokenizer):
     note, it could be unsuited for tracks with long pauses. In such case, the
     maximum *TimeShift* value will be used.
 
-    :param pitch_range: range of MIDI pitches to use
-    :param beat_res: beat resolutions, as a dictionary:
-            {(beat_x1, beat_x2): beat_res_1, (beat_x2, beat_x3): beat_res_2, ...}
-            The keys are tuples indicating a range of beats, ex 0 to 3 for the first bar, and
-            the values are the resolution to apply to the ranges, in samples per beat, ex 8
-    :param nb_velocities: number of velocity bins
-    :param additional_tokens: additional tokens (chords, time signature, rests, tempo...) to use,
-            to be given as a dictionary. (default: None is used)
-    :param special_tokens: list of special tokens. This must be given as a list of strings given
-            only the names of the tokens. (default: ``["PAD", "BOS", "EOS", "MASK"]``)
+    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
     :param params: path to a tokenizer config file. This will override other arguments and
             load the tokenizer based on the config file. This is particularly useful if the
             tokenizer learned Byte Pair Encoding. (default: None)
     """
 
     def __init__(
-        self,
-        pitch_range: range = PITCH_RANGE,
-        beat_res: Dict[Tuple[int, int], int] = BEAT_RES,
-        nb_velocities: int = NB_VELOCITIES,
-        additional_tokens: Dict[str, bool] = ADDITIONAL_TOKENS,
-        special_tokens: List[str] = SPECIAL_TOKENS,
-        params: Union[str, Path] = None,
+        self, tokenizer_config: TokenizerConfig = None, params: Union[str, Path] = None
     ):
-        additional_tokens["TimeSignature"] = False  # not compatible
-        super().__init__(
-            pitch_range,
-            beat_res,
-            nb_velocities,
-            additional_tokens,
-            special_tokens,
-            params=params,
-        )
+        super().__init__(tokenizer_config, False, params)
+
+    def _tweak_config_before_creating_voc(self):
+        self.config.use_time_signatures = False
 
     @_out_as_complete_seq
     def track_to_tokens(self, track: Instrument) -> TokSequence:
@@ -74,13 +49,13 @@ class MIDILike(MIDITokenizer):
         # Make sure the notes are sorted first by their onset (start) times, second by pitch
         # notes.sort(key=lambda x: (x.start, x.pitch))  # done in midi_to_tokens
         ticks_per_sample = self._current_midi_metadata["time_division"] / max(
-            self.beat_res.values()
+            self.config.beat_res.values()
         )
         dur_bins = self._durations_ticks[self._current_midi_metadata["time_division"]]
         min_rest = (
             self._current_midi_metadata["time_division"] * self.rests[0][0]
             + ticks_per_sample * self.rests[0][1]
-            if self.additional_tokens["Rest"]
+            if self.config.use_rests
             else 0
         )
         events = []
@@ -105,7 +80,7 @@ class MIDILike(MIDITokenizer):
                 Event(type="NoteOff", value=note.pitch, time=note.end, desc=note.end)
             )
         # Adds tempo events if specified
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             for tempo_change in self._current_midi_metadata["tempo_changes"]:
                 events.append(
                     Event(
@@ -129,7 +104,7 @@ class MIDILike(MIDITokenizer):
 
             # (Rest)
             elif (
-                self.additional_tokens["Rest"]
+                self.config.use_rests
                 and event.type in ["NoteOn", "Tempo"]
                 and event.time - previous_note_end >= min_rest
             ):
@@ -200,14 +175,14 @@ class MIDILike(MIDITokenizer):
             previous_tick = event.time
 
         # Adds chord events if specified
-        if self.additional_tokens["Chord"] and not track.is_drum:
+        if self.config.use_chords and not track.is_drum:
             events += detect_chords(
                 track.notes,
                 self._current_midi_metadata["time_division"],
-                chord_maps=self.additional_tokens["chord_maps"],
-                specify_root_note=self.additional_tokens["chord_tokens_with_root_note"],
+                chord_maps=self.config.chord_maps,
+                specify_root_note=self.config.chord_tokens_with_root_note,
                 beat_res=self._first_beat_res,
-                unknown_chords_nb_notes_range=self.additional_tokens["chord_unknown"],
+                unknown_chords_nb_notes_range=self.config.chord_unknown,
             )
 
         events.sort(key=lambda x: (x.time, self._order(x)))
@@ -232,7 +207,7 @@ class MIDILike(MIDITokenizer):
                                 note off event. Leave None to discard Note On with no Note Off event.
         :return: the miditoolkit instrument object and tempo changes
         """
-        ticks_per_sample = time_division // max(self.beat_res.values())
+        ticks_per_sample = time_division // max(self.config.beat_res.values())
         events = (
             tokens.events
             if tokens.events is not None
@@ -321,10 +296,10 @@ class MIDILike(MIDITokenizer):
         vocab = []
 
         # NOTE ON
-        vocab += [f"NoteOn_{i}" for i in self.pitch_range]
+        vocab += [f"NoteOn_{i}" for i in range(*self.config.pitch_range)]
 
         # NOTE OFF
-        vocab += [f"NoteOff_{i}" for i in self.pitch_range]
+        vocab += [f"NoteOff_{i}" for i in range(*self.config.pitch_range)]
 
         # VELOCITY
         vocab += [f"Velocity_{i}" for i in self.velocities]
@@ -335,19 +310,19 @@ class MIDILike(MIDITokenizer):
         ]
 
         # CHORD
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             vocab += self._create_chords_tokens()
 
         # REST
-        if self.additional_tokens["Rest"]:
+        if self.config.use_rests:
             vocab += [f'Rest_{".".join(map(str, rest))}' for rest in self.rests]
 
         # TEMPO
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             vocab += [f"Tempo_{i}" for i in self.tempos]
 
         # PROGRAM
-        if self.additional_tokens["Program"]:
+        if self.config.use_programs:
             vocab += [f"Program_{program}" for program in range(-1, 128)]
 
         return vocab
@@ -367,20 +342,20 @@ class MIDILike(MIDITokenizer):
         dic["TimeShift"] = ["NoteOff", "NoteOn"]
         dic["NoteOff"] = ["NoteOff", "NoteOn", "TimeShift"]
 
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             dic["Chord"] = ["NoteOn"]
             dic["TimeShift"] += ["Chord"]
             dic["NoteOff"] += ["Chord"]
 
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             dic["TimeShift"] += ["Tempo"]
             dic["Tempo"] = ["NoteOn", "TimeShift"]
-            if self.additional_tokens["Chord"]:
+            if self.config.use_chords:
                 dic["Tempo"] += ["Chord"]
 
-        if self.additional_tokens["Rest"]:
+        if self.config.use_rests:
             dic["Rest"] = ["Rest", "NoteOn", "TimeShift"]
-            if self.additional_tokens["Chord"]:
+            if self.config.use_chords:
                 dic["Rest"] += ["Chord"]
             dic["NoteOff"] += ["Rest"]
 
@@ -406,9 +381,9 @@ class MIDILike(MIDITokenizer):
 
         err = 0
         current_pitches = []
-        max_duration = self.durations[-1][0] * max(self.beat_res.values())
+        max_duration = self.durations[-1][0] * max(self.config.beat_res.values())
         max_duration += self.durations[-1][1] * (
-            max(self.beat_res.values()) // self.durations[-1][2]
+            max(self.config.beat_res.values()) // self.durations[-1][2]
         )
 
         events = (
@@ -435,7 +410,7 @@ class MIDILike(MIDITokenizer):
                             break  # all good
                         elif events[j].type == "TimeShift":
                             offset_sample += self._token_duration_to_ticks(
-                                events[j].value, max(self.beat_res.values())
+                                events[j].value, max(self.config.beat_res.values())
                             )
 
                         if (

--- a/miditok/tokenizations/midi_like.py
+++ b/miditok/tokenizations/midi_like.py
@@ -1,11 +1,10 @@
 from typing import List, Tuple, Dict, Optional, Union, Any
-from pathlib import Path
 
 import numpy as np
 from miditoolkit import Instrument, Note, TempoChange
 
 from ..midi_tokenizer import MIDITokenizer, _in_as_seq, _out_as_complete_seq
-from ..classes import TokSequence, Event, TokenizerConfig
+from ..classes import TokSequence, Event
 from ..utils import detect_chords
 from ..constants import (
     TIME_DIVISION,
@@ -23,17 +22,7 @@ class MIDILike(MIDITokenizer):
     **Note:** as MIDI-Like uses *TimeShifts* events to move the time from note to
     note, it could be unsuited for tracks with long pauses. In such case, the
     maximum *TimeShift* value will be used.
-
-    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
-    :param params: path to a tokenizer config file. This will override other arguments and
-            load the tokenizer based on the config file. This is particularly useful if the
-            tokenizer learned Byte Pair Encoding. (default: None)
     """
-
-    def __init__(
-        self, tokenizer_config: TokenizerConfig = None, params: Union[str, Path] = None
-    ):
-        super().__init__(tokenizer_config, False, params)
 
     def _tweak_config_before_creating_voc(self):
         self.config.use_time_signatures = False

--- a/miditok/tokenizations/mmm.py
+++ b/miditok/tokenizations/mmm.py
@@ -4,14 +4,9 @@ from typing import Any, Dict, List, Optional, Tuple, Union, cast
 import numpy as np
 from miditoolkit import Instrument, MidiFile, Note, TempoChange, TimeSignature
 
-from ..classes import Event, TokSequence
+from ..classes import Event, TokSequence, TokenizerConfig
 from ..constants import (
-    ADDITIONAL_TOKENS,
-    BEAT_RES,
     MIDI_INSTRUMENTS,
-    NB_VELOCITIES,
-    PITCH_RANGE,
-    SPECIAL_TOKENS,
     TEMPO,
     TIME_DIVISION,
     TIME_SIGNATURE,
@@ -31,16 +26,7 @@ class MMM(MIDITokenizer):
     strategy of the [original paper](https://arxiv.org/abs/2008.06048). The reason being that ``NoteOff`` tokens perform
     poorer for generation with causal models.
 
-    :param pitch_range: range of MIDI pitches to use
-    :param beat_res: beat resolutions, as a dictionary:
-            {(beat_x1, beat_x2): beat_res_1, (beat_x2, beat_x3): beat_res_2, ...}
-            The keys are tuples indicating a range of beats, ex 0 to 3 for the first bar, and
-            the values are the resolution to apply to the ranges, in samples per beat, ex 8
-    :param nb_velocities: number of velocity bins
-    :param additional_tokens: additional tokens (chords, time signature, rests, tempo...) to use,
-            to be given as a dictionary. (default: None is used)
-    :param special_tokens: list of special tokens. This must be given as a list of strings given
-            only the names of the tokens. (default: ``["PAD", "BOS", "EOS", "MASK"]``)
+    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
     :param density_bins_max: tuple specifying the number of density bins, and the maximum density in
             notes per beat to consider. (default: (10, 20))
     :param params: path to a tokenizer config file. This will override other arguments and
@@ -50,32 +36,19 @@ class MMM(MIDITokenizer):
 
     def __init__(
         self,
-        pitch_range: range = PITCH_RANGE,
-        beat_res: Dict[Tuple[int, int], int] = BEAT_RES,
-        nb_velocities: int = NB_VELOCITIES,
-        additional_tokens: Dict[
-            str, Union[bool, int, Tuple[int, int]]
-        ] = ADDITIONAL_TOKENS,
-        special_tokens: List[str] = SPECIAL_TOKENS,
+        tokenizer_config: TokenizerConfig = None,
         density_bins_max: Tuple[int, int] = MMM_DENSITY_BINS_MAX,
         params: Optional[Union[str, Path]] = None,
     ):
-        additional_tokens["Program"] = True  # required
-        additional_tokens["Rest"] = False
-        self.programs = additional_tokens.get("programs", list(range(-1, 128)))
         self.density_bins_max = density_bins_max
         self.note_densities = np.linspace(
             0, density_bins_max[1], density_bins_max[0] + 1, dtype=np.intc
         )
-        super().__init__(
-            pitch_range,
-            beat_res,
-            nb_velocities,
-            additional_tokens,
-            special_tokens,
-            unique_track=True,  # handles multi-track sequences in single stream
-            params=params,  # type: ignore
-        )
+        super().__init__(tokenizer_config, True, params)
+
+    def _tweak_config_before_creating_voc(self):
+        self.config.use_programs = True
+        self.config.use_rests = False
 
     def save_params(
         self, out_path: Union[str, Path], additional_attributes: Optional[Dict] = None
@@ -129,20 +102,20 @@ class MMM(MIDITokenizer):
         ]
 
         # (Chord)
-        if self.additional_tokens.get("Chord", False) and not track.is_drum:
+        if self.config.use_chords and not track.is_drum:
             chords = detect_chords(
                 track.notes,
                 self._current_midi_metadata["time_division"],
-                chord_maps=self.additional_tokens["chord_maps"],
-                specify_root_note=self.additional_tokens["chord_tokens_with_root_note"],
+                chord_maps=self.config.chord_maps,
+                specify_root_note=self.config.chord_tokens_with_root_note,
                 beat_res=self._first_beat_res,
-                unknown_chords_nb_notes_range=self.additional_tokens["chord_unknown"],
+                unknown_chords_nb_notes_range=self.config.chord_unknown,
             )
             for chord in chords:
                 events.append(chord)
 
         # (Tempo)
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             for tempo_change in self._current_midi_metadata["tempo_changes"]:
                 events.append(
                     Event(
@@ -154,7 +127,7 @@ class MMM(MIDITokenizer):
                 )
 
         # (Time signature)
-        if self.additional_tokens["TimeSignature"]:
+        if self.config.use_time_signatures:
             for time_sig in self._current_midi_metadata["time_sig_changes"]:
                 events.append(
                     Event(
@@ -295,10 +268,10 @@ class MMM(MIDITokenizer):
         tokens = cast(TokSequence, tokens)
         midi = MidiFile(ticks_per_beat=time_division)
         assert (
-            time_division % max(self.beat_res.values()) == 0
-        ), f"Invalid time division, please give one divisible by {max(self.beat_res.values())}"
+            time_division % max(self.config.beat_res.values()) == 0
+        ), f"Invalid time division, please give one divisible by {max(self.config.beat_res.values())}"
         tokens = cast(List[str], tokens.tokens)  # for reducing type errors
-        ticks_per_sample = time_division // max(self.beat_res.values())
+        ticks_per_sample = time_division // max(self.config.beat_res.values())
 
         # RESULTS
         instruments: List[Instrument] = []
@@ -312,7 +285,6 @@ class MMM(MIDITokenizer):
 
         current_tick = 0
         current_bar = -1
-        current_program = 0
         previous_note_end = 0  # unused (rest)
         for ti, token in enumerate(tokens):
             tok_type, tok_val = token.split("_")
@@ -428,7 +400,7 @@ class MMM(MIDITokenizer):
         vocab += ["Fill_Start", "Fill_End"]
 
         # PITCH
-        vocab += [f"Pitch_{i}" for i in self.pitch_range]
+        vocab += [f"Pitch_{i}" for i in range(*self.config.pitch_range)]
 
         # VELOCITY
         vocab += [f"Velocity_{i}" for i in self.velocities]
@@ -448,20 +420,19 @@ class MMM(MIDITokenizer):
         vocab += [f"NoteDensity_{i}" for i in self.note_densities]
 
         # TIME SIGNATURE
-        if self.additional_tokens["TimeSignature"]:
+        if self.config.use_time_signatures:
             vocab += [f"TimeSig_{i[0]}/{i[1]}" for i in self.time_signatures]
 
         # CHORD
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             vocab += self._create_chords_tokens()
 
         # TEMPO
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             vocab += [f"Tempo_{i}" for i in self.tempos]
 
         # PROGRAM
-        if self.additional_tokens["Program"]:
-            vocab += [f"Program_{program}" for program in self.programs]
+        vocab += [f"Program_{program}" for program in self.config.programs]
 
         return vocab
 
@@ -482,20 +453,20 @@ class MMM(MIDITokenizer):
         dic["Velocity"] = ["Duration"]
         dic["Duration"] = ["Pitch", "TimeShift", "Bar"]
 
-        if self.additional_tokens["TimeSignature"]:
+        if self.config.use_time_signatures:
             dic["Bar"] += ["TimeSig"]
             dic["TimeSig"] = ["Pitch", "TimeShift"]
 
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             dic["Chord"] = ["TimeShift", "Pitch"]
             dic["Bar"] += ["Chord"]
             dic["TimeShift"] += ["Chord"]
 
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             dic["Tempo"] = ["TimeShift", "Pitch", "Bar"]
             dic["Bar"] += ["Tempo"]
             dic["TimeShift"] += ["Tempo"]
-            if self.additional_tokens["TimeSignature"]:
+            if self.config.use_time_signatures:
                 dic["TimeSig"] += ["Tempo"]
 
         dic["Fill"] = list(dic.keys())

--- a/miditok/tokenizations/octuple.py
+++ b/miditok/tokenizations/octuple.py
@@ -6,13 +6,8 @@ import numpy as np
 from miditoolkit import MidiFile, Instrument, Note, TempoChange, TimeSignature
 
 from ..midi_tokenizer import MIDITokenizer, _in_as_seq, _out_as_complete_seq
-from ..classes import TokSequence, Event
+from ..classes import TokSequence, Event, TokenizerConfig
 from ..constants import (
-    PITCH_RANGE,
-    NB_VELOCITIES,
-    BEAT_RES,
-    ADDITIONAL_TOKENS,
-    SPECIAL_TOKENS,
     TIME_DIVISION,
     TIME_SIGNATURE,
     TEMPO,
@@ -45,52 +40,30 @@ class Octuple(MIDITokenizer):
     * Tokens are first sorted by time, then track, then pitch values.
     * Tracks with the same *Program* will be merged.
 
-    :param pitch_range: range of MIDI pitches to use
-    :param beat_res: beat resolutions, as a dictionary:
-            {(beat_x1, beat_x2): beat_res_1, (beat_x2, beat_x3): beat_res_2, ...}
-            The keys are tuples indicating a range of beats, ex 0 to 3 for the first bar, and
-            the values are the resolution to apply to the ranges, in samples per beat, ex 8
-    :param nb_velocities: number of velocity bins
-    :param additional_tokens: additional tokens (chords, time signature, rests, tempo...) to use,
-            to be given as a dictionary. (default: None is used)
-    :param special_tokens: list of special tokens. This must be given as a list of strings given
-            only the names of the tokens. (default: ``["PAD", "BOS", "EOS", "MASK"]``)
+    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
     :param params: path to a tokenizer config file. This will override other arguments and
             load the tokenizer based on the config file. This is particularly useful if the
             tokenizer learned Byte Pair Encoding. (default: None)
     """
 
     def __init__(
-        self,
-        pitch_range: range = PITCH_RANGE,
-        beat_res: Dict[Tuple[int, int], int] = BEAT_RES,
-        nb_velocities: int = NB_VELOCITIES,
-        additional_tokens: Dict[str, bool] = ADDITIONAL_TOKENS,
-        special_tokens: List[str] = SPECIAL_TOKENS,
-        params: Union[str, Path] = None,
+        self, tokenizer_config: TokenizerConfig = None, params: Union[str, Path] = None
     ):
-        additional_tokens["Chord"] = False  # Incompatible additional token
-        additional_tokens["Rest"] = False
+        super().__init__(tokenizer_config, True, params)
+
+    def _tweak_config_before_creating_voc(self):
+        self.config.use_chords = False
+        self.config.use_rests = False
         # used in place of positional encoding
-        self.programs = additional_tokens.get("programs", list(range(-1, 128)))
         self.max_bar_embedding = 60  # this attribute might increase during encoding
         token_types = ["Pitch", "Velocity", "Duration", "Program", "Position", "Bar"]
-        if additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             token_types.append("Tempo")
-        if additional_tokens["TimeSignature"]:
+        if self.config.use_time_signatures:
             token_types.append("TimeSignature")
         self.vocab_types_idx = {
             type_: idx for idx, type_ in enumerate(token_types)
         }  # used for data augmentation
-        super().__init__(
-            pitch_range,
-            beat_res,
-            nb_velocities,
-            additional_tokens,
-            special_tokens,
-            True,
-            params=params,
-        )
 
     def save_params(
         self, out_path: Union[str, Path, PurePath], additional_attributes: Dict = None
@@ -108,7 +81,6 @@ class Octuple(MIDITokenizer):
             additional_attributes = {}
         additional_attributes_tmp = {
             "max_bar_embedding": self.max_bar_embedding,
-            "programs": self.programs,
             **additional_attributes,
         }
         super().save_params(out_path, additional_attributes_tmp)
@@ -163,12 +135,12 @@ class Octuple(MIDITokenizer):
         # Convert each track to tokens
         tokens = []
         for track in midi.instruments:
-            if track.program in self.programs:
+            if track.program in self.config.programs:
                 tokens += self.track_to_tokens(track)
 
         tokens.sort(
             key=lambda x: (x[0].time, x[0].desc, x[0].value)
-        )  # Sort by time then track then pitch
+        )  # Sort by time, then track, then pitch
 
         # Convert pitch events into tokens
         for time_step in tokens:
@@ -195,7 +167,7 @@ class Octuple(MIDITokenizer):
         # Make sure the notes are sorted first by their onset (start) times, second by pitch
         # notes.sort(key=lambda x: (x.start, x.pitch))  # done in midi_to_tokens
         time_division = self.current_midi_metadata["time_division"]
-        ticks_per_sample = time_division / max(self.beat_res.values())
+        ticks_per_sample = time_division / max(self.config.beat_res.values())
         dur_bins = self._durations_ticks[time_division]
 
         tokens = []
@@ -249,7 +221,7 @@ class Octuple(MIDITokenizer):
             ]
 
             # (Tempo)
-            if self.additional_tokens["Tempo"]:
+            if self.config.use_tempos:
                 # If the current tempo is not the last one
                 if current_tempo_idx + 1 < len(
                     self.current_midi_metadata["tempo_changes"]
@@ -269,7 +241,7 @@ class Octuple(MIDITokenizer):
                 token.append(f"Tempo_{current_tempo}")
 
             # (TimeSignature)
-            if self.additional_tokens["TimeSignature"]:
+            if self.config.use_time_signatures:
                 # If the current time signature is not the last one
                 if current_time_sig_idx + 1 < len(
                     self.current_midi_metadata["time_sig_changes"]
@@ -326,21 +298,21 @@ class Octuple(MIDITokenizer):
         :return: the midi object (miditoolkit.MidiFile)
         """
         assert (
-            time_division % max(self.beat_res.values()) == 0
-        ), f"Invalid time division, please give one divisible by {max(self.beat_res.values())}"
+            time_division % max(self.config.beat_res.values()) == 0
+        ), f"Invalid time division, please give one divisible by {max(self.config.beat_res.values())}"
         midi = MidiFile(ticks_per_beat=time_division)
-        ticks_per_sample = time_division // max(self.beat_res.values())
+        ticks_per_sample = time_division // max(self.config.beat_res.values())
         tokens = tokens.tokens
 
         tempo_changes = [TempoChange(TEMPO, 0)]
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             for i in range(len(tokens)):
                 if tokens[i][6].split("_")[1] != "None":
                     tempo_changes = [TempoChange(int(tokens[i][6].split("_")[1]), 0)]
                     break
 
         time_sig = TIME_SIGNATURE
-        if self.additional_tokens["TimeSignature"]:
+        if self.config.use_time_signatures:
             for i in range(len(tokens)):
                 if tokens[i][-1].split("_")[1] != "None":
                     time_sig = self._parse_token_time_signature(
@@ -382,14 +354,14 @@ class Octuple(MIDITokenizer):
             )
 
             # Tempo, adds a TempoChange if necessary
-            if self.additional_tokens["Tempo"] and time_step[6].split("_")[1] != "None":
+            if self.config.use_tempos and time_step[6].split("_")[1] != "None":
                 tempo = int(time_step[6].split("_")[1])
                 if tempo != tempo_changes[-1].tempo:
                     tempo_changes.append(TempoChange(tempo, current_tick))
 
             # Time Signature, adds a TimeSignatureChange if necessary
             if (
-                self.additional_tokens["TimeSignature"]
+                self.config.use_time_signatures
                 and time_step[-1].split("_")[1] != "None"
             ):
                 time_sig = self._parse_token_time_signature(time_step[-1].split("_")[1])
@@ -463,7 +435,7 @@ class Octuple(MIDITokenizer):
         vocab = [[] for _ in range(6)]
 
         # PITCH
-        vocab[0] += [f"Pitch_{i}" for i in self.pitch_range]
+        vocab[0] += [f"Pitch_{i}" for i in range(*self.config.pitch_range)]
 
         # VELOCITY
         vocab[1] += [f"Velocity_{i}" for i in self.velocities]
@@ -474,10 +446,10 @@ class Octuple(MIDITokenizer):
         ]
 
         # PROGRAM
-        vocab[3] += [f"Program_{i}" for i in self.programs]
+        vocab[3] += [f"Program_{i}" for i in self.config.programs]
 
         # POSITION
-        nb_positions = max(self.beat_res.values()) * 4  # 4/4 time signature
+        nb_positions = max(self.config.beat_res.values()) * 4  # 4/4 time signature
         vocab[4] += [f"Position_{i}" for i in range(nb_positions)]
 
         # BAR
@@ -486,11 +458,11 @@ class Octuple(MIDITokenizer):
         ]  # bar embeddings (positional encoding)
 
         # TEMPO
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             vocab.append([f"Tempo_{i}" for i in self.tempos])
 
         # TIME_SIGNATURE
-        if self.additional_tokens["TimeSignature"]:
+        if self.config.use_time_signatures:
             vocab.append([f"TimeSig_{i[0]}/{i[1]}" for i in self.time_signatures])
 
         return vocab
@@ -519,7 +491,7 @@ class Octuple(MIDITokenizer):
         """
         err = 0
         current_bar = current_pos = -1
-        current_pitches = {p: [] for p in self.programs}
+        current_pitches = {p: [] for p in self.config.programs}
 
         for token in tokens.tokens:
             if any(tok.split("_")[1] == "None" for tok in token):
@@ -537,14 +509,14 @@ class Octuple(MIDITokenizer):
             elif bar_value > current_bar:
                 current_bar = bar_value
                 current_pos = -1
-                current_pitches = {p: [] for p in self.programs}
+                current_pitches = {p: [] for p in self.config.programs}
 
             # Position
             if pos_value < current_pos:
                 has_error = True
             elif pos_value > current_pos:
                 current_pos = pos_value
-                current_pitches = {p: [] for p in self.programs}
+                current_pitches = {p: [] for p in self.config.programs}
 
             # Pitch
             if pitch_value in current_pitches[program_value]:

--- a/miditok/tokenizations/remi.py
+++ b/miditok/tokenizations/remi.py
@@ -5,14 +5,9 @@ import numpy as np
 from miditoolkit import Instrument, Note, TempoChange
 
 from ..midi_tokenizer import MIDITokenizer, _in_as_seq, _out_as_complete_seq
-from ..classes import TokSequence, Event
+from ..classes import TokSequence, Event, TokenizerConfig
 from ..utils import detect_chords
 from ..constants import (
-    PITCH_RANGE,
-    NB_VELOCITIES,
-    BEAT_RES,
-    ADDITIONAL_TOKENS,
-    SPECIAL_TOKENS,
     TIME_DIVISION,
     TEMPO,
     MIDI_INSTRUMENTS,
@@ -32,40 +27,19 @@ class REMI(MIDITokenizer):
     *TempoValue* indicating its value. MidiTok only uses one *Tempo* token for its value
     (see :ref:`Additional tokens`).
 
-    :param pitch_range: range of MIDI pitches to use
-    :param beat_res: beat resolutions, as a dictionary:
-            {(beat_x1, beat_x2): beat_res_1, (beat_x2, beat_x3): beat_res_2, ...}
-            The keys are tuples indicating a range of beats, ex 0 to 3 for the first bar, and
-            the values are the resolution to apply to the ranges, in samples per beat, ex 8
-    :param nb_velocities: number of velocity bins
-    :param additional_tokens: additional tokens (chords, time signature, rests, tempo...) to use,
-            to be given as a dictionary. (default: None is used)
-    :param special_tokens: list of special tokens. This must be given as a list of strings given
-            only the names of the tokens. (default: ``["PAD", "BOS", "EOS", "MASK"]``)
+    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
     :param params: path to a tokenizer config file. This will override other arguments and
             load the tokenizer based on the config file. This is particularly useful if the
             tokenizer learned Byte Pair Encoding. (default: None)
     """
 
     def __init__(
-        self,
-        pitch_range: range = PITCH_RANGE,
-        beat_res: Dict[Tuple[int, int], int] = BEAT_RES,
-        nb_velocities: int = NB_VELOCITIES,
-        additional_tokens: Dict[str, Union[bool, int]] = ADDITIONAL_TOKENS,
-        special_tokens: List[str] = SPECIAL_TOKENS,
-        params: Union[str, Path] = None,
+        self, tokenizer_config: TokenizerConfig = None, params: Union[str, Path] = None
     ):
-        self.encoder = []
-        additional_tokens["TimeSignature"] = False  # not compatible
-        super().__init__(
-            pitch_range,
-            beat_res,
-            nb_velocities,
-            additional_tokens,
-            special_tokens,
-            params=params,
-        )
+        super().__init__(tokenizer_config, False, params)
+
+    def _tweak_config_before_creating_voc(self):
+        self.config.use_time_signatures = False
 
     @_out_as_complete_seq
     def track_to_tokens(self, track: Instrument) -> TokSequence:
@@ -77,14 +51,14 @@ class REMI(MIDITokenizer):
         # Make sure the notes are sorted first by their onset (start) times, second by pitch
         # notes.sort(key=lambda x: (x.start, x.pitch))  # done in midi_to_tokens
         ticks_per_sample = self._current_midi_metadata["time_division"] / max(
-            self.beat_res.values()
+            self.config.beat_res.values()
         )
         ticks_per_bar = self._current_midi_metadata["time_division"] * 4
         dur_bins = self._durations_ticks[self._current_midi_metadata["time_division"]]
         min_rest = (
             self._current_midi_metadata["time_division"] * self.rests[0][0]
             + ticks_per_sample * self.rests[0][1]
-            if self.additional_tokens["Rest"]
+            if self.config.use_rests
             else 0
         )
 
@@ -104,7 +78,7 @@ class REMI(MIDITokenizer):
             if note.start != previous_tick:
                 # (Rest)
                 if (
-                    self.additional_tokens["Rest"]
+                    self.config.use_rests
                     and note.start > previous_note_end
                     and note.start - previous_note_end >= min_rest
                 ):
@@ -171,7 +145,7 @@ class REMI(MIDITokenizer):
                 )
 
                 # (Tempo)
-                if self.additional_tokens["Tempo"]:
+                if self.config.use_tempos:
                     # If the current tempo is not the last one
                     if current_tempo_idx + 1 < len(
                         self._current_midi_metadata["tempo_changes"]
@@ -225,14 +199,14 @@ class REMI(MIDITokenizer):
             previous_note_end = max(previous_note_end, note.end)
 
         # Adds chord events if specified
-        if self.additional_tokens["Chord"] and not track.is_drum:
+        if self.config.use_chords and not track.is_drum:
             events += detect_chords(
                 track.notes,
                 self._current_midi_metadata["time_division"],
-                chord_maps=self.additional_tokens["chord_maps"],
-                specify_root_note=self.additional_tokens["chord_tokens_with_root_note"],
+                chord_maps=self.config.chord_maps,
+                specify_root_note=self.config.chord_tokens_with_root_note,
                 beat_res=self._first_beat_res,
-                unknown_chords_nb_notes_range=self.additional_tokens["chord_unknown"],
+                unknown_chords_nb_notes_range=self.config.chord_unknown,
             )
 
         events.sort(key=lambda x: (x.time, self._order(x)))
@@ -255,11 +229,11 @@ class REMI(MIDITokenizer):
         :return: the miditoolkit instrument object and tempo changes
         """
         assert (
-            time_division % max(self.beat_res.values()) == 0
-        ), f"Invalid time division, please give one divisible by {max(self.beat_res.values())}"
+            time_division % max(self.config.beat_res.values()) == 0
+        ), f"Invalid time division, please give one divisible by {max(self.config.beat_res.values())}"
         tokens = tokens.tokens
 
-        ticks_per_sample = time_division // max(self.beat_res.values())
+        ticks_per_sample = time_division // max(self.config.beat_res.values())
         ticks_per_bar = time_division * 4
         name = "Drums" if program[1] else MIDI_INSTRUMENTS[program[0]]["name"]
         instrument = Instrument(program[0], is_drum=program[1], name=name)
@@ -338,7 +312,7 @@ class REMI(MIDITokenizer):
         vocab = ["Bar_None"]
 
         # PITCH
-        vocab += [f"Pitch_{i}" for i in self.pitch_range]
+        vocab += [f"Pitch_{i}" for i in range(*self.config.pitch_range)]
 
         # VELOCITY
         vocab += [f"Velocity_{i}" for i in self.velocities]
@@ -349,23 +323,23 @@ class REMI(MIDITokenizer):
         ]
 
         # POSITION
-        nb_positions = max(self.beat_res.values()) * 4  # 4/4 time signature
+        nb_positions = max(self.config.beat_res.values()) * 4  # 4/4 time signature
         vocab += [f"Position_{i}" for i in range(nb_positions)]
 
         # CHORD
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             vocab += self._create_chords_tokens()
 
         # REST
-        if self.additional_tokens["Rest"]:
+        if self.config.use_rests:
             vocab += [f'Rest_{".".join(map(str, rest))}' for rest in self.rests]
 
         # TEMPO
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             vocab += [f"Tempo_{i}" for i in self.tempos]
 
         # PROGRAM
-        if self.additional_tokens["Program"]:
+        if self.config.use_programs:
             vocab += [f"Program_{program}" for program in range(-1, 128)]
 
         return vocab
@@ -387,21 +361,19 @@ class REMI(MIDITokenizer):
         dic["Velocity"] = ["Duration"]
         dic["Duration"] = ["Pitch", "Position", "Bar"]
 
-        if self.additional_tokens["Program"]:
+        if self.config.use_programs:
             dic["Program"] = ["Bar"]
 
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             dic["Chord"] = ["Pitch"]
             dic["Duration"] += ["Chord"]
             dic["Position"] += ["Chord"]
 
-        if self.additional_tokens["Tempo"]:
-            dic["Tempo"] = (
-                ["Chord", "Pitch"] if self.additional_tokens["Chord"] else ["Pitch"]
-            )
+        if self.config.use_tempos:
+            dic["Tempo"] = ["Chord", "Pitch"] if self.config.use_chords else ["Pitch"]
             dic["Position"] += ["Tempo"]
 
-        if self.additional_tokens["Rest"]:
+        if self.config.use_rests:
             dic["Rest"] = ["Rest", "Position", "Bar"]
             dic["Duration"] += ["Rest"]
 

--- a/miditok/tokenizations/remi.py
+++ b/miditok/tokenizations/remi.py
@@ -1,11 +1,10 @@
 from typing import List, Tuple, Dict, Optional, Union, Any
-from pathlib import Path
 
 import numpy as np
 from miditoolkit import Instrument, Note, TempoChange
 
 from ..midi_tokenizer import MIDITokenizer, _in_as_seq, _out_as_complete_seq
-from ..classes import TokSequence, Event, TokenizerConfig
+from ..classes import TokSequence, Event
 from ..utils import detect_chords
 from ..constants import (
     TIME_DIVISION,
@@ -26,17 +25,7 @@ class REMI(MIDITokenizer):
     of two token types: a *TempoClass* indicating if the tempo is fast or slow, and a
     *TempoValue* indicating its value. MidiTok only uses one *Tempo* token for its value
     (see :ref:`Additional tokens`).
-
-    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
-    :param params: path to a tokenizer config file. This will override other arguments and
-            load the tokenizer based on the config file. This is particularly useful if the
-            tokenizer learned Byte Pair Encoding. (default: None)
     """
-
-    def __init__(
-        self, tokenizer_config: TokenizerConfig = None, params: Union[str, Path] = None
-    ):
-        super().__init__(tokenizer_config, False, params)
 
     def _tweak_config_before_creating_voc(self):
         self.config.use_time_signatures = False

--- a/miditok/tokenizations/remi_plus.py
+++ b/miditok/tokenizations/remi_plus.py
@@ -51,6 +51,11 @@ class REMIPlus(MIDITokenizer):
         self.config.use_rests = False
         # self.unique_track = True
 
+        # In case the tokenizer has been created without specifying any config or params file path
+        if "max_bar_embedding" not in self.config.additional_params:
+            # If used, this attribute might increase over tokenizations, if the tokenizer encounter longer MIDIs
+            self.config.additional_params["max_bar_embedding"] = None
+
     def __notes_to_events(self, tracks: List[Instrument]) -> List[Event]:
         """Convert multi-track notes into one Token sequence.
 

--- a/miditok/tokenizations/remi_plus.py
+++ b/miditok/tokenizations/remi_plus.py
@@ -5,14 +5,9 @@ from typing import Any, Dict, List, Optional, Tuple, Union, cast
 import numpy as np
 from miditoolkit import Instrument, MidiFile, Note, TempoChange, TimeSignature
 
-from ..classes import Event, TokSequence
+from ..classes import Event, TokSequence, TokenizerConfig
 from ..constants import (
-    ADDITIONAL_TOKENS,
-    BEAT_RES,
     MIDI_INSTRUMENTS,
-    NB_VELOCITIES,
-    PITCH_RANGE,
-    SPECIAL_TOKENS,
     TEMPO,
     TIME_DIVISION,
     TIME_SIGNATURE,
@@ -31,51 +26,28 @@ class REMIPlus(MIDITokenizer):
     position within the current bar. The number of positions is determined by
     the ``beat_res`` argument, the maximum value will be used as resolution.
 
-    :param pitch_range: range of MIDI pitches to use
-    :param beat_res: beat resolutions, as a dictionary:
-            {(beat_x1, beat_x2): beat_res_1, (beat_x2, beat_x3): beat_res_2, ...}
-            The keys are tuples indicating a range of beats, ex 0 to 3 for the first bar, and
-            the values are the resolution to apply to the ranges, in samples per beat, ex 8
-    :param nb_velocities: number of velocity bins
-    :param additional_tokens: additional tokens (chords, time signature, rests, tempo...) to use,
-            to be given as a dictionary. (default: None is used)
-    :param special_tokens: list of special tokens. This must be given as a list of strings given
-            only the names of the tokens. (default: ``["PAD", "BOS", "EOS", "MASK"]``)
+    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
+    :param max_bar_embedding: Maximum number of bars ("Bar_0", "Bar_1",...,"Bar_{num_bars-1}").
+            If None passed, creates "Bar_None" token only in vocabulary for Bar token.
     :param params: path to a tokenizer config file. This will override other arguments and
             load the tokenizer based on the config file. This is particularly useful if the
             tokenizer learned Byte Pair Encoding. (default: None)
-    :param max_bar_embedding: Maximum number of bars ("Bar_0", "Bar_1",...,"Bar_{num_bars-1}").
-            If None passed, creates "Bar_None" token only in vocabulary for Bar token.
     """
 
     def __init__(
         self,
-        pitch_range: range = PITCH_RANGE,
-        beat_res: Dict[Tuple[int, int], int] = BEAT_RES,
-        nb_velocities: int = NB_VELOCITIES,
-        additional_tokens: Dict[
-            str, Union[bool, int, Tuple[int, int]]
-        ] = ADDITIONAL_TOKENS,
-        special_tokens: List[str] = SPECIAL_TOKENS,
-        params: Optional[Union[str, Path]] = None,
+        tokenizer_config: TokenizerConfig = None,
         max_bar_embedding: Optional[int] = None,
+        params: Union[str, Path] = None,
     ):
-        additional_tokens["Program"] = True  # required
+        # this attribute might increase over tokenizations, if the tokenizer encounter longer MIDIs
+        self.max_bar_embedding = max_bar_embedding
+        super().__init__(tokenizer_config, True, params)
+
+    def _tweak_config_before_creating_voc(self):
+        self.config.use_programs = True
         # code handling rest decoding is writen, but not for detection (encoding)
-        additional_tokens["Rest"] = False
-        self.programs = additional_tokens.get("programs", list(range(-1, 128)))
-        self.max_bar_embedding = (
-            max_bar_embedding  # this attribute might increase during encoding
-        )
-        super().__init__(
-            pitch_range,
-            beat_res,
-            nb_velocities,
-            additional_tokens,
-            special_tokens,
-            unique_track=True,  # handles multi-track sequences in single stream
-            params=params,  # type: ignore
-        )
+        self.config.use_rests = False
 
     def save_params(
         self, out_path: Union[str, Path], additional_attributes: Optional[Dict] = None
@@ -112,7 +84,7 @@ class REMIPlus(MIDITokenizer):
         # Make sure the notes are sorted first by their onset (start) times, second by pitch
         # notes.sort(key=lambda x: (x.start, x.pitch))  # done in midi_to_tokens
         time_division = self._current_midi_metadata["time_division"]
-        ticks_per_sample = time_division / max(self.beat_res.values())
+        ticks_per_sample = time_division / max(self.config.beat_res.values())
         dur_bins = self._durations_ticks[self._current_midi_metadata["time_division"]]
         # Creates events
         events: List[Event] = []
@@ -148,21 +120,17 @@ class REMIPlus(MIDITokenizer):
         )
         ticks_per_bar = time_division * current_time_sig[0]
         # (Chord)
-        if self.additional_tokens.get("Chord", False):  # "Chord" in additional tokens
+        if self.config.use_chords:  # "Chord" in additional tokens
             for track in tracks:  # find chords per track
                 if track.is_drum:
                     continue
                 chords = detect_chords(
                     track.notes,
                     self._current_midi_metadata["time_division"],
-                    chord_maps=self.additional_tokens["chord_maps"],
-                    specify_root_note=self.additional_tokens[
-                        "chord_tokens_with_root_note"
-                    ],
+                    chord_maps=self.config.chord_maps,
+                    specify_root_note=self.config.chord_tokens_with_root_note,
                     beat_res=self._first_beat_res,
-                    unknown_chords_nb_notes_range=self.additional_tokens[
-                        "chord_unknown"
-                    ],
+                    unknown_chords_nb_notes_range=self.config.chord_unknown,
                 )
                 for chord in chords:
                     pos_index = int((chord.time % ticks_per_bar) / ticks_per_sample)
@@ -193,7 +161,7 @@ class REMIPlus(MIDITokenizer):
                 current_bar += nb_new_bars
 
                 # (TimeSignature)
-                if self.additional_tokens["TimeSignature"]:
+                if self.config.use_time_signatures:
                     # If the current time signature is not the last one
                     if current_time_sig_idx + 1 < len(
                         self._current_midi_metadata["time_sig_changes"]
@@ -226,7 +194,7 @@ class REMIPlus(MIDITokenizer):
                         )
 
                 # (Tempo)
-                if self.additional_tokens["Tempo"]:
+                if self.config.use_tempos:
                     is_tempo_changed = False
                     # If the current tempo is not the last one
                     if current_tempo_idx + 1 < len(
@@ -373,10 +341,10 @@ class REMIPlus(MIDITokenizer):
         tokens = cast(TokSequence, tokens)
         midi = MidiFile(ticks_per_beat=time_division)
         assert (
-            time_division % max(self.beat_res.values()) == 0
-        ), f"Invalid time division, please give one divisible by {max(self.beat_res.values())}"
+            time_division % max(self.config.beat_res.values()) == 0
+        ), f"Invalid time division, please give one divisible by {max(self.config.beat_res.values())}"
         tokens = cast(List[str], tokens.tokens)  # for reducing type errors
-        ticks_per_sample = time_division // max(self.beat_res.values())
+        ticks_per_sample = time_division // max(self.config.beat_res.values())
 
         # RESULTS
         instruments: Dict[int, Instrument] = {}
@@ -501,7 +469,7 @@ class REMIPlus(MIDITokenizer):
             vocab += ["Bar_None"]
 
         # PITCH
-        vocab += [f"Pitch_{i}" for i in self.pitch_range]
+        vocab += [f"Pitch_{i}" for i in range(*self.config.pitch_range)]
 
         # VELOCITY
         vocab += [f"Velocity_{i}" for i in self.velocities]
@@ -512,24 +480,23 @@ class REMIPlus(MIDITokenizer):
         ]
 
         # POSITION
-        nb_positions = max(self.beat_res.values()) * 4  # 4/4 time signature
+        nb_positions = max(self.config.beat_res.values()) * 4  # 4/4 time signature
         vocab += [f"Position_{i}" for i in range(nb_positions)]
 
         # TIME SIGNATURE
-        if self.additional_tokens["TimeSignature"]:
+        if self.config.use_time_signatures:
             vocab += [f"TimeSig_{i[0]}/{i[1]}" for i in self.time_signatures]
 
         # CHORD
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             vocab += self._create_chords_tokens()
 
         # TEMPO
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             vocab += [f"Tempo_{i}" for i in self.tempos]
 
         # PROGRAM
-        if self.additional_tokens["Program"]:
-            vocab += [f"Program_{program}" for program in self.programs]
+        vocab += [f"Program_{program}" for program in self.config.programs]
 
         return vocab
 
@@ -548,15 +515,15 @@ class REMIPlus(MIDITokenizer):
         dic["Velocity"] = ["Duration"]
         dic["Duration"] = ["Program", "Position", "Bar"]
 
-        if self.additional_tokens["TimeSignature"]:
+        if self.config.use_time_signatures:
             dic["Bar"] = ["TimeSig", "Bar"]
             dic["TimeSig"] = ["Position"]
 
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             dic["Chord"] = ["Position"]
             dic["Position"] += ["Chord"]
 
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             dic["Tempo"] = ["Position"]
             dic["Position"] += ["Tempo"]
 
@@ -601,7 +568,7 @@ class REMIPlus(MIDITokenizer):
         previous_type = tokens[0].split("_")[0]
         current_pos = -1
         current_program = 0
-        current_pitches = {p: [] for p in self.programs}
+        current_pitches = {p: [] for p in self.config.programs}
 
         # Init first note and current pitches if needed
         if previous_type == "Pitch":
@@ -617,7 +584,7 @@ class REMIPlus(MIDITokenizer):
             if event_type in self.tokens_types_graph[previous_type]:
                 if event_type == "Bar":  # reset
                     current_pos = -1
-                    current_pitches = {p: [] for p in self.programs}
+                    current_pitches = {p: [] for p in self.config.programs}
                 elif previous_type == "Pitch":
                     pitch_val = int(event_value)
                     if pitch_val in current_pitches[current_program]:
@@ -629,7 +596,7 @@ class REMIPlus(MIDITokenizer):
                         err_time += 1  # token position value <= to the current position
                     else:
                         current_pos = int(event_value)
-                        current_pitches = {p: [] for p in self.programs}
+                        current_pitches = {p: [] for p in self.config.programs}
                 elif event_type == "Program":  # reset
                     current_program = int(event_value)
             # Bad token type

--- a/miditok/tokenizations/structured.py
+++ b/miditok/tokenizations/structured.py
@@ -1,11 +1,10 @@
 from typing import List, Tuple, Dict, Optional, Union, Any
-from pathlib import Path
 
 import numpy as np
 from miditoolkit import Instrument, Note, TempoChange
 
 from ..midi_tokenizer import MIDITokenizer, _in_as_seq, _out_as_complete_seq
-from ..classes import TokSequence, Event, TokenizerConfig
+from ..classes import TokSequence, Event
 from ..constants import (
     TIME_DIVISION,
     TEMPO,
@@ -23,17 +22,7 @@ class Structured(MIDITokenizer):
     **Note:** as Structured uses *TimeShifts* events to move the time from note to
     note, it could be unsuited for tracks with long pauses. In such case, the
     maximum *TimeShift* value will be used.
-
-    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
-    :param params: path to a tokenizer config file. This will override other arguments and
-            load the tokenizer based on the config file. This is particularly useful if the
-            tokenizer learned Byte Pair Encoding. (default: None)
     """
-
-    def __init__(
-        self, tokenizer_config: TokenizerConfig = None, params: Union[str, Path] = None
-    ):
-        super().__init__(tokenizer_config, False, params)
 
     def _tweak_config_before_creating_voc(self):
         self.config.use_chords = False

--- a/miditok/tokenizations/structured.py
+++ b/miditok/tokenizations/structured.py
@@ -5,13 +5,8 @@ import numpy as np
 from miditoolkit import Instrument, Note, TempoChange
 
 from ..midi_tokenizer import MIDITokenizer, _in_as_seq, _out_as_complete_seq
-from ..classes import TokSequence, Event
+from ..classes import TokSequence, Event, TokenizerConfig
 from ..constants import (
-    PITCH_RANGE,
-    NB_VELOCITIES,
-    BEAT_RES,
-    ADDITIONAL_TOKENS,
-    SPECIAL_TOKENS,
     TIME_DIVISION,
     TEMPO,
     MIDI_INSTRUMENTS,
@@ -29,43 +24,22 @@ class Structured(MIDITokenizer):
     note, it could be unsuited for tracks with long pauses. In such case, the
     maximum *TimeShift* value will be used.
 
-    :param pitch_range: range of MIDI pitches to use
-    :param beat_res: beat resolutions, as a dictionary:
-            {(beat_x1, beat_x2): beat_res_1, (beat_x2, beat_x3): beat_res_2, ...}
-            The keys are tuples indicating a range of beats, ex 0 to 3 for the first bar, and
-            the values are the resolution to apply to the ranges, in samples per beat, ex 8
-    :param nb_velocities: number of velocity bins
-    :param additional_tokens: additional tokens (chords, time signature, rests, tempo...) to use,
-            to be given as a dictionary. (default: None is used)
-    :param special_tokens: list of special tokens. This must be given as a list of strings given
-            only the names of the tokens. (default: ``["PAD", "BOS", "EOS", "MASK"]``)
+    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
     :param params: path to a tokenizer config file. This will override other arguments and
             load the tokenizer based on the config file. This is particularly useful if the
             tokenizer learned Byte Pair Encoding. (default: None)
     """
 
     def __init__(
-        self,
-        pitch_range: range = PITCH_RANGE,
-        beat_res: Dict[Tuple[int, int], int] = BEAT_RES,
-        nb_velocities: int = NB_VELOCITIES,
-        additional_tokens: Dict[str, Union[bool, int]] = ADDITIONAL_TOKENS,
-        special_tokens: List[str] = SPECIAL_TOKENS,
-        params: Union[str, Path] = None,
+        self, tokenizer_config: TokenizerConfig = None, params: Union[str, Path] = None
     ):
-        # No additional tokens
-        additional_tokens["Chord"] = False  # Incompatible additional token
-        additional_tokens["Rest"] = False
-        additional_tokens["Tempo"] = False
-        additional_tokens["TimeSignature"] = False
-        super().__init__(
-            pitch_range,
-            beat_res,
-            nb_velocities,
-            additional_tokens,
-            special_tokens,
-            params=params,
-        )
+        super().__init__(tokenizer_config, False, params)
+
+    def _tweak_config_before_creating_voc(self):
+        self.config.use_chords = False
+        self.config.use_rests = False
+        self.config.use_tempos = False
+        self.config.use_time_signatures = False
 
     @_out_as_complete_seq
     def track_to_tokens(self, track: Instrument) -> TokSequence:
@@ -138,7 +112,7 @@ class Structured(MIDITokenizer):
                 )
             )
         # Adds the last note
-        if track.notes[-1].pitch not in self.pitch_range:
+        if track.notes[-1].pitch not in range(*self.config.pitch_range):
             if len(events) > 0:
                 del events[-1]
         else:
@@ -241,7 +215,7 @@ class Structured(MIDITokenizer):
         vocab = []
 
         # PITCH
-        vocab += [f"Pitch_{i}" for i in self.pitch_range]
+        vocab += [f"Pitch_{i}" for i in range(*self.config.pitch_range)]
 
         # VELOCITY
         vocab += [f"Velocity_{i}" for i in self.velocities]
@@ -258,7 +232,7 @@ class Structured(MIDITokenizer):
         ]
 
         # PROGRAM
-        if self.additional_tokens["Program"]:
+        if self.config.use_programs:
             vocab += [f"Program_{program}" for program in range(-1, 128)]
 
         return vocab

--- a/miditok/tokenizations/tsd.py
+++ b/miditok/tokenizations/tsd.py
@@ -5,14 +5,9 @@ import numpy as np
 from miditoolkit import Instrument, Note, TempoChange
 
 from ..midi_tokenizer import MIDITokenizer, _in_as_seq, _out_as_complete_seq
-from ..classes import TokSequence, Event
+from ..classes import TokSequence, Event, TokenizerConfig
 from ..utils import detect_chords
 from ..constants import (
-    PITCH_RANGE,
-    NB_VELOCITIES,
-    BEAT_RES,
-    ADDITIONAL_TOKENS,
-    SPECIAL_TOKENS,
     TIME_DIVISION,
     TEMPO,
     MIDI_INSTRUMENTS,
@@ -26,40 +21,21 @@ class TSD(MIDITokenizer):
     **Note:** as TSD uses *TimeShifts* events to move the time from note to
     note, it could be unsuited for tracks with long pauses. In such case, the
     maximum *TimeShift* value will be used.
+    TODO handle programs like REMIPlus
 
-    :param pitch_range: range of MIDI pitches to use
-    :param beat_res: beat resolutions, as a dictionary:
-            {(beat_x1, beat_x2): beat_res_1, (beat_x2, beat_x3): beat_res_2, ...}
-            The keys are tuples indicating a range of beats, ex 0 to 3 for the first bar, and
-            the values are the resolution to apply to the ranges, in samples per beat, ex 8
-    :param nb_velocities: number of velocity bins
-    :param additional_tokens: additional tokens (chords, time signature, rests, tempo...) to use,
-            to be given as a dictionary. (default: None is used)
-    :param special_tokens: list of special tokens. This must be given as a list of strings given
-            only the names of the tokens. (default: ``["PAD", "BOS", "EOS", "MASK"]``)
+    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
     :param params: path to a tokenizer config file. This will override other arguments and
             load the tokenizer based on the config file. This is particularly useful if the
             tokenizer learned Byte Pair Encoding. (default: None)
     """
 
     def __init__(
-        self,
-        pitch_range: range = PITCH_RANGE,
-        beat_res: Dict[Tuple[int, int], int] = BEAT_RES,
-        nb_velocities: int = NB_VELOCITIES,
-        additional_tokens: Dict[str, bool] = ADDITIONAL_TOKENS,
-        special_tokens: List[str] = SPECIAL_TOKENS,
-        params: Union[str, Path] = None,
+        self, tokenizer_config: TokenizerConfig = None, params: Union[str, Path] = None
     ):
-        additional_tokens["TimeSignature"] = False  # not compatible
-        super().__init__(
-            pitch_range,
-            beat_res,
-            nb_velocities,
-            additional_tokens,
-            special_tokens,
-            params=params,
-        )
+        super().__init__(tokenizer_config, False, params)
+
+    def _tweak_config_before_creating_voc(self):
+        self.config.use_time_signatures = False
 
     @_out_as_complete_seq
     def track_to_tokens(self, track: Instrument) -> TokSequence:
@@ -72,13 +48,13 @@ class TSD(MIDITokenizer):
         # Make sure the notes are sorted first by their onset (start) times, second by pitch
         # notes.sort(key=lambda x: (x.start, x.pitch))  # done in midi_to_tokens
         ticks_per_sample = self._current_midi_metadata["time_division"] / max(
-            self.beat_res.values()
+            self.config.beat_res.values()
         )
         dur_bins = self._durations_ticks[self._current_midi_metadata["time_division"]]
         min_rest = (
             self._current_midi_metadata["time_division"] * self.rests[0][0]
             + ticks_per_sample * self.rests[0][1]
-            if self.additional_tokens["Rest"]
+            if self.config.use_rests
             else 0
         )
         events = []
@@ -108,7 +84,7 @@ class TSD(MIDITokenizer):
                 )
             )
         # Adds tempo events if specified
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             for tempo_change in self._current_midi_metadata["tempo_changes"]:
                 events.append(
                     Event(
@@ -133,7 +109,7 @@ class TSD(MIDITokenizer):
             # (Rest)
             elif (
                 event.type in ["Pitch", "Tempo"]
-                and self.additional_tokens["Rest"]
+                and self.config.use_rests
                 and event.time - previous_note_end >= min_rest
             ):
                 rest_beat, rest_pos = divmod(
@@ -203,14 +179,14 @@ class TSD(MIDITokenizer):
             previous_tick = event.time
 
         # Adds chord events if specified
-        if self.additional_tokens["Chord"] and not track.is_drum:
+        if self.config.use_chords and not track.is_drum:
             events += detect_chords(
                 track.notes,
                 self._current_midi_metadata["time_division"],
-                chord_maps=self.additional_tokens["chord_maps"],
-                specify_root_note=self.additional_tokens["chord_tokens_with_root_note"],
+                chord_maps=self.config.chord_maps,
+                specify_root_note=self.config.chord_tokens_with_root_note,
                 beat_res=self._first_beat_res,
-                unknown_chords_nb_notes_range=self.additional_tokens["chord_unknown"],
+                unknown_chords_nb_notes_range=self.config.chord_unknown,
             )
 
         events.sort(key=lambda x: (x.time, self._order(x)))
@@ -232,7 +208,7 @@ class TSD(MIDITokenizer):
         :param program: the MIDI program of the produced track and if it drum, (default (0, False), piano)
         :return: the miditoolkit instrument object and tempo changes
         """
-        ticks_per_sample = time_division // max(self.beat_res.values())
+        ticks_per_sample = time_division // max(self.config.beat_res.values())
         tokens = tokens.tokens
 
         name = "Drums" if program[1] else MIDI_INSTRUMENTS[program[0]]["name"]
@@ -292,7 +268,7 @@ class TSD(MIDITokenizer):
         vocab = []
 
         # NOTE ON
-        vocab += [f"Pitch_{i}" for i in self.pitch_range]
+        vocab += [f"Pitch_{i}" for i in range(*self.config.pitch_range)]
 
         # VELOCITY
         vocab += [f"Velocity_{i}" for i in self.velocities]
@@ -309,19 +285,19 @@ class TSD(MIDITokenizer):
         ]
 
         # CHORD
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             vocab += self._create_chords_tokens()
 
         # REST
-        if self.additional_tokens["Rest"]:
+        if self.config.use_rests:
             vocab += [f'Rest_{".".join(map(str, rest))}' for rest in self.rests]
 
         # TEMPO
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             vocab += [f"Tempo_{i}" for i in self.tempos]
 
         # PROGRAM
-        if self.additional_tokens["Program"]:
+        if self.config.use_programs:
             vocab += [f"Program_{program}" for program in range(-1, 128)]
 
         return vocab
@@ -341,19 +317,19 @@ class TSD(MIDITokenizer):
         dic["Duration"] = ["Pitch", "TimeShift"]
         dic["TimeShift"] = ["Pitch"]
 
-        if self.additional_tokens["Chord"]:
+        if self.config.use_chords:
             dic["Chord"] = ["Pitch"]
             dic["TimeShift"] += ["Chord"]
 
-        if self.additional_tokens["Tempo"]:
+        if self.config.use_tempos:
             dic["TimeShift"] += ["Tempo"]
             dic["Tempo"] = ["Pitch", "TimeShift"]
-            if self.additional_tokens["Chord"]:
+            if self.config.use_chords:
                 dic["Tempo"] += ["Chord"]
 
-        if self.additional_tokens["Rest"]:
+        if self.config.use_rests:
             dic["Rest"] = ["Rest", "Pitch", "TimeShift"]
-            if self.additional_tokens["Chord"]:
+            if self.config.use_chords:
                 dic["Rest"] += ["Chord"]
             dic["Duration"] += ["Rest"]
 

--- a/miditok/tokenizations/tsd.py
+++ b/miditok/tokenizations/tsd.py
@@ -1,11 +1,10 @@
 from typing import List, Tuple, Dict, Optional, Union, Any
-from pathlib import Path
 
 import numpy as np
 from miditoolkit import Instrument, Note, TempoChange
 
 from ..midi_tokenizer import MIDITokenizer, _in_as_seq, _out_as_complete_seq
-from ..classes import TokSequence, Event, TokenizerConfig
+from ..classes import TokSequence, Event
 from ..utils import detect_chords
 from ..constants import (
     TIME_DIVISION,
@@ -22,17 +21,7 @@ class TSD(MIDITokenizer):
     note, it could be unsuited for tracks with long pauses. In such case, the
     maximum *TimeShift* value will be used.
     TODO handle programs like REMIPlus
-
-    :param tokenizer_config: the tokenizer's configuration, as a :class:`miditok.classes.TokenizerConfig` object.
-    :param params: path to a tokenizer config file. This will override other arguments and
-            load the tokenizer based on the config file. This is particularly useful if the
-            tokenizer learned Byte Pair Encoding. (default: None)
     """
-
-    def __init__(
-        self, tokenizer_config: TokenizerConfig = None, params: Union[str, Path] = None
-    ):
-        super().__init__(tokenizer_config, False, params)
 
     def _tweak_config_before_creating_voc(self):
         self.config.use_time_signatures = False

--- a/miditok/utils/utils.py
+++ b/miditok/utils/utils.py
@@ -70,7 +70,7 @@ def detect_chords(
     specify_root_note: bool = True,
     beat_res: int = 4,
     onset_offset: int = 1,
-    unknown_chords_nb_notes_range: Union[bool, Tuple[int]] = False,
+    unknown_chords_nb_notes_range: Tuple[int, int] = None,
     simul_notes_limit: int = 10,
 ) -> List[Event]:
     r"""Chord detection method. Make sure to sort notes by start time then pitch before:
@@ -84,14 +84,16 @@ def detect_chords(
     :param notes: notes to analyse (sorted by starting time, them pitch)
     :param time_division: MIDI time division / resolution, in ticks/beat (of the MIDI being parsed)
     :param chord_maps: list of chord maps, to be given as a dictionary where keys are chord qualities
-                    (e.g. "maj") and values pitch maps as tuples of integers (e.g. (0, 4, 7)).
-                    You can use or take as an example ``miditok.constants.CHORD_MAPS``.
-    :param specify_root_note: the root note of each chord will be specified in Events / tokens (default: True).
+            (e.g. "maj") and values pitch maps as tuples of integers (e.g. (0, 4, 7)).
+            You can use ``miditok.constants.CHORD_MAPS`` as an example.
+    :param specify_root_note: the root note of each chord will be specified in Events / tokens.
+            Tokens will look as "Chord_C:maj". (default: True)
     :param beat_res: beat resolution, i.e. nb of samples per beat (default 4).
     :param onset_offset: maximum offset (in samples) ∈ N separating notes starts to consider them
-                    starting at the same time / onset (default is 1).
-    :param unknown_chords_nb_notes_range: will detect only chords recognized in the chord maps. If set to False,
-                    non recognized chords of *n* notes will give a *Chord_n* token (default False).
+            starting at the same time / onset (default is 1).
+    :param unknown_chords_nb_notes_range: range of number of notes to represent unknown chords.
+            If you want to represent chords that does not match any combination in ``chord_maps``, use this argument.
+            Leave ``None`` to not represent unknown chords. (default: None)
     :param simul_notes_limit: nb of simultaneous notes being processed when looking for a chord
             this parameter allows to speed up the chord detection, and must be >= 5 (default 10).
     :return: the detected chords as Event objects.
@@ -148,7 +150,7 @@ def detect_chords(
                     break
 
             # We found a chord quality, or we specify unknown chords
-            if not (unknown_chords_nb_notes_range is False and is_unknown_chord):
+            if not (unknown_chords_nb_notes_range is not None and is_unknown_chord):
                 if specify_root_note:
                     chord_quality = (
                         f"{PITCH_CLASSES[notes[count, 0] % 12]}:{chord_quality}"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author="Nathan Fradet",
     url="https://github.com/Natooz/MidiTok",
     packages=find_packages(exclude=("tests",)),
-    version="2.0.7",
+    version="2.1.0",
     license="MIT",
     description="A convenient MIDI tokenizer for Deep Learning networks, with multiple encoding strategies",
     long_description=long_description,

--- a/tests/benchmark_fast_bpe.py
+++ b/tests/benchmark_fast_bpe.py
@@ -69,8 +69,7 @@ def bpe_benchmark(data_path: Union[str, Path, PurePath] = "./tests/Maestro"):
 
     # Record times
     t = PrettyTable(
-        ["Tokenization", "Fast train"]
-        + [f"Fast enc. bsz={b}" for b in batch_sizes],
+        ["Tokenization", "Fast train"] + [f"Fast enc. bsz={b}" for b in batch_sizes],
         title="BPE benchmark: Fast = with 🤗tokenizers (Rust), "
         "values are in second, bsz is batch size",
     )

--- a/tests/test_bpe.py
+++ b/tests/test_bpe.py
@@ -16,12 +16,13 @@ from tqdm import tqdm
 # Special beat res for test, up to 64 beats so the duration and time-shift values are
 # long enough for MIDI-Like and Structured encodings, and with a single beat resolution
 BEAT_RES_TEST = {(0, 4): 8, (4, 12): 4}
-ADDITIONAL_TOKENS_TEST = {
-    "Chord": False,  # set false to speed up tests as it takes some time on maestro MIDIs
-    "Rest": True,
-    "Tempo": True,
-    "TimeSignature": True,
-    "Program": False,
+TOKENIZER_PARAMS = {
+    "beat_res": BEAT_RES_TEST,
+    "use_chords": False,  # set false to speed up tests as it takes some time on maestro MIDIs
+    "use_rests": True,
+    "use_tempos": True,
+    "use_time_signatures": True,
+    "use_programs": False,
     "rest_range": (4, 16),
     "nb_tempos": 32,
     "tempo_range": (40, 250),
@@ -47,9 +48,9 @@ def test_bpe_conversion(
     first_tokenizers = []
     first_samples_bpe = {tok: [] for tok in tokenizations}
     for tokenization in tokenizations:
-        add_tokens = deepcopy(ADDITIONAL_TOKENS_TEST)
+        tokenizer_config = miditok.TokenizerConfig(**TOKENIZER_PARAMS)
         tokenizer: miditok.MIDITokenizer = getattr(miditok, tokenization)(
-            beat_res=BEAT_RES_TEST, additional_tokens=add_tokens
+            tokenizer_config=tokenizer_config
         )
         tokenizer.tokenize_midi_dataset(
             files, Path("tests", "test_results", tokenization)

--- a/tests/test_multitrack.py
+++ b/tests/test_multitrack.py
@@ -34,12 +34,13 @@ from .tests_utils import (
 # Special beat res for test, up to 16 beats so the duration and time-shift values are
 # long enough for MIDI-Like and Structured encodings, and with a single beat resolution
 BEAT_RES_TEST = {(0, 16): 8}
-ADDITIONAL_TOKENS_TEST = {
-    "Chord": True,
-    "Rest": True,
-    "Tempo": True,
-    "TimeSignature": True,
-    "Program": True,
+TOKENIZER_PARAMS = {
+    "beat_res": BEAT_RES_TEST,
+    "use_chords": True,
+    "use_rests": True,
+    "use_tempos": True,
+    "use_time_signatures": True,
+    "use_programs": True,
     "chord_maps": miditok.constants.CHORD_MAPS,
     "chord_tokens_with_root_note": True,  # Tokens will look as "Chord_C:maj"
     "chord_unknown": (3, 6),
@@ -87,9 +88,9 @@ def test_multitrack_midi_to_tokens_to_midi(
         has_errors = False
 
         for tokenization in tokenizations:
-            tokenizer = getattr(miditok, tokenization)(
-                beat_res=BEAT_RES_TEST,
-                additional_tokens=deepcopy(ADDITIONAL_TOKENS_TEST),
+            tokenizer_config = miditok.TokenizerConfig(**TOKENIZER_PARAMS)
+            tokenizer: miditok.MIDITokenizer = getattr(miditok, tokenization)(
+                tokenizer_config=tokenizer_config
             )
 
             # Process the MIDI
@@ -159,7 +160,7 @@ def test_multitrack_midi_to_tokens_to_midi(
 
             # Checks tempos
             if (
-                tokenizer.additional_tokens["Tempo"] and tokenization != "MuMIDI"
+                tokenizer.config.use_tempos and tokenization != "MuMIDI"
             ):  # MuMIDI doesn't decode tempos
                 tempo_errors = tempo_changes_equals(
                     midi_to_compare.tempo_changes, new_midi.tempo_changes
@@ -172,7 +173,7 @@ def test_multitrack_midi_to_tokens_to_midi(
                     )
 
             # Checks time signatures
-            if tokenizer.additional_tokens["TimeSignature"] and tokenization in [
+            if tokenizer.config.use_time_signatures and tokenization in [
                 "Octuple",
                 "REMIPlus",
             ]:

--- a/tests/test_saving_loading_config.py
+++ b/tests/test_saving_loading_config.py
@@ -5,17 +5,15 @@ If all went well the tokenizer should be identical.
 
 """
 
-from copy import deepcopy
-
 import miditok
 
 
 ADDITIONAL_TOKENS_TEST = {
-    "Chord": False,  # set False to speed up tests as it takes some time on maestro MIDIs
-    "Rest": True,
-    "Tempo": True,
-    "TimeSignature": True,
-    "Program": False,
+    "use_chords": False,  # set False to speed up tests as it takes some time on maestro MIDIs
+    "use_rests": True,
+    "use_tempos": True,
+    "use_time_signatures": True,
+    "use_programs": False,
     "rest_range": (4, 16),
     "nb_tempos": 32,
     "tempo_range": (40, 250),
@@ -40,9 +38,9 @@ def test_saving_loading_tokenizer():
     ]
 
     for tokenization in tokenizations:
-        add_tokens = deepcopy(ADDITIONAL_TOKENS_TEST)
+        tokenizer_config = miditok.TokenizerConfig(**ADDITIONAL_TOKENS_TEST)
         tokenizer: miditok.MIDITokenizer = getattr(miditok, tokenization)(
-            additional_tokens=add_tokens
+            tokenizer_config=tokenizer_config
         )
         tokenizer.save_params(f"./tests/configs/{tokenization}.txt")
 

--- a/tests/test_saving_loading_config.py
+++ b/tests/test_saving_loading_config.py
@@ -19,23 +19,35 @@ ADDITIONAL_TOKENS_TEST = {
     "tempo_range": (40, 250),
     "time_signature_range": (16, 2),
 }
+tokenizations = [
+    "MIDILike",
+    "TSD",
+    "Structured",
+    "REMI",
+    "REMIPlus",
+    "CPWord",
+    "Octuple",
+    "OctupleMono",
+    "MuMIDI",
+]
+
+
+def test_saving_loading_tokenizer_config():
+    for tokenization in tokenizations:
+        config1 = miditok.TokenizerConfig()
+        config1.save_to_json(f"./tests/configs/tok_conf_{tokenization}.json")
+
+        config2 = miditok.TokenizerConfig.load_from_json(f"./tests/configs/tok_conf_{tokenization}.json")
+
+        assert config1 == config2
+        config1.pitch_range = (0, 777)
+        assert config1 != config2
 
 
 def test_saving_loading_tokenizer():
     r"""Tests to create tokenizers, save their config, and load it back.
     If all went well the tokenizer should be identical.
     """
-    tokenizations = [
-        "MIDILike",
-        "TSD",
-        "Structured",
-        "REMI",
-        "REMIPlus",
-        "CPWord",
-        "Octuple",
-        "OctupleMono",
-        "MuMIDI",
-    ]
 
     for tokenization in tokenizations:
         tokenizer_config = miditok.TokenizerConfig(**ADDITIONAL_TOKENS_TEST)
@@ -54,4 +66,5 @@ def test_saving_loading_tokenizer():
 
 
 if __name__ == "__main__":
+    test_saving_loading_tokenizer_config()
     test_saving_loading_tokenizer()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,7 +31,9 @@ def test_merge_tracks():
     merge_tracks(midi, effects=True)
     assert len(midi.instruments[0].notes) == 4 * len(original_track.notes)
     assert len(midi.instruments[0].pedals) == 2 * len(original_track.pedals)
-    assert len(midi.instruments[0].control_changes) == 2 * len(original_track.control_changes)
+    assert len(midi.instruments[0].control_changes) == 2 * len(
+        original_track.control_changes
+    )
     assert len(midi.instruments[0].pitch_bends) == 2 * len(original_track.pitch_bends)
 
 


### PR DESCRIPTION
This PR adds a `TokenizerConfig` class that holds the common parameters of all tokenizers, such as `beat_res`, `nb_velocities` or the entries of the previous `additional_tokens` attribute.
This object is hold by tokenizers as a `.config` attribute.

It greatly simplifies the way to instantiate tokenizers, as well as saving and loading their parameters.

`save_params` overrides are also removed, allowing a uniformisation of tokenizer parameters saving and loading. `load_params` is still compatible with previous versions (< v2.1.0).