### PR TITLE
Configure tempo values scale

### DIFF
--- a/miditok/classes.py
+++ b/miditok/classes.py
@@ -25,6 +25,7 @@ from .constants import (
     CHORD_UNKNOWN,
     NB_TEMPOS,
     TEMPO_RANGE,
+    LOG_TEMPOS,
     TIME_SIGNATURE_RANGE,
     PROGRAMS,
     CURRENT_VERSION_PACKAGE,
@@ -181,6 +182,7 @@ class TokenizerConfig:
             Leave ``None`` to not represent unknown chords. (default: None)
     :param nb_tempos: number of tempos "bins" to use. (default: 32)
     :param tempo_range: range of minimum and maximum tempos within which the bins fall. (default: (40, 250))
+    :param log_tempos: will use log scaled tempo values instead of linearly scaled. (default: False)
     :param time_signature_range: range as a tuple (max_beat_res, nb_notes). (default: (8, 2))
     :param programs: sequence of MIDI programs to use. Note that `-1` is used and reserved for drums tracks.
             (default: from -1 to 127 included)
@@ -204,6 +206,7 @@ class TokenizerConfig:
         chord_unknown: Tuple[int, int] = CHORD_UNKNOWN,
         nb_tempos: int = NB_TEMPOS,
         tempo_range: Tuple[int, int] = TEMPO_RANGE,
+        log_tempos: bool = LOG_TEMPOS,
         time_signature_range: Tuple[int, int] = TIME_SIGNATURE_RANGE,
         programs: Sequence[int] = PROGRAMS,
         **kwargs,
@@ -234,6 +237,7 @@ class TokenizerConfig:
         # Tempo params
         self.nb_tempos: int = nb_tempos  # nb of tempo bins for additional tempo tokens, quantized like velocities
         self.tempo_range: Tuple[int, int] = tempo_range  # (min_tempo, max_tempo)
+        self.log_tempos: bool = log_tempos
 
         # Time signature params
         self.time_signature_range: Tuple[int, int] = time_signature_range

--- a/miditok/constants.py
+++ b/miditok/constants.py
@@ -61,6 +61,7 @@ UNKNOWN_CHORD_PREFIX = "ukn"  # only used in methods
 # nb of tempo bins for additional tempo tokens, quantized like velocities
 NB_TEMPOS = 32
 TEMPO_RANGE = (40, 250)  # (min_tempo, max_tempo)
+LOG_TEMPOS = False  # log or linear scale tempos
 
 # Time signature params
 TIME_SIGNATURE_RANGE = (8, 2)

--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -226,11 +226,7 @@ class MIDITokenizer(ABC):
         # Tempos
         self.tempos = np.zeros(1)
         if self.config.use_tempos:
-            self.tempos = np.linspace(
-                *self.config.tempo_range,
-                self.config.nb_tempos,
-                dtype=np.intc,
-            )
+            self.tempos = self.__create_tempos()
 
         # Rests
         self.rests = []
@@ -954,6 +950,19 @@ class MIDITokenizer(ABC):
             div //= 2
         rests += [(i, 0) for i in range(1, max_beat + 1)]
         return rests
+
+    def __create_tempos(self) -> np.ndarray:
+        r"""Creates the possible tempos, as a float number array.
+
+        The self.config.nb_tempos tempos are distributed in the self.config.tempo_range
+        using either log or linear scaled values based on the value of self.config.log_tempos.
+
+        :return: the tempos.
+        """
+        tempo_fn = np.geomspace if self.config.log_tempos else np.linspace
+        tempos = tempo_fn(*self.config.tempo_range, self.config.nb_tempos).round(2)
+
+        return tempos
 
     def __create_time_signatures(self) -> List[Tuple]:
         r"""Creates the possible time signatures, as tuples of the form:

--- a/miditok/tokenizations/cp_word.py
+++ b/miditok/tokenizations/cp_word.py
@@ -221,7 +221,7 @@ class CPWord(MIDITokenizer):
         dur: str = None,
         chord: str = None,
         rest: str = None,
-        tempo: int = None,
+        tempo: float = None,
         program: int = None,
         desc: str = "",
     ) -> List[Union[Event, str]]:
@@ -344,7 +344,7 @@ class CPWord(MIDITokenizer):
                         + int(compound_token[1].split("_")[1]) * ticks_per_sample
                     )
                     if self.config.use_tempos:
-                        tempo = int(compound_token[-1].split("_")[1])
+                        tempo = float(compound_token[-1].split("_")[1])
                         if tempo != tempo_changes[-1].tempo:
                             tempo_changes.append(TempoChange(tempo, current_tick))
                 elif (

--- a/miditok/tokenizations/midi_like.py
+++ b/miditok/tokenizations/midi_like.py
@@ -261,7 +261,7 @@ class MIDILike(MIDITokenizer):
                 beat, pos = map(int, events[ei].value.split("."))
                 current_tick += beat * time_division + pos * ticks_per_sample
             elif events[ei].type == "Tempo":
-                tempo = int(events[ei].value)
+                tempo = float(events[ei].value)
                 if tempo != tempo_changes[-1].tempo:
                     tempo_changes.append(TempoChange(tempo, current_tick))
             ei += 1

--- a/miditok/tokenizations/mmm.py
+++ b/miditok/tokenizations/mmm.py
@@ -320,7 +320,7 @@ class MMM(MIDITokenizer):
             elif tok_type == "Tempo":
                 # If the tokenizer includes tempo tokens, each Position token should be followed by
                 # a tempo token, but if it is not the case this method will skip this step
-                tempo = int(token.split("_")[1])
+                tempo = float(token.split("_")[1])
                 if tempo != tempo_changes[-1].tempo:
                     tempo_changes.append(TempoChange(tempo, current_tick))
             elif tok_type == "TimeSig":

--- a/miditok/tokenizations/mumidi.py
+++ b/miditok/tokenizations/mumidi.py
@@ -301,7 +301,7 @@ class MuMIDI(MIDITokenizer):
 
         # Tempos
         if self.config.use_tempos:
-            first_tempo = int(tokens.tokens[0][3].split("_")[1])
+            first_tempo = float(tokens.tokens[0][3].split("_")[1])
         else:
             first_tempo = TEMPO
         midi.tempo_changes.append(TempoChange(first_tempo, 0))
@@ -344,7 +344,7 @@ class MuMIDI(MIDITokenizer):
 
             # Decode tempo if required
             if self.config.use_tempos:
-                tempo_val = int(time_step[3].split("_")[1])
+                tempo_val = float(time_step[3].split("_")[1])
                 if tempo_val != midi.tempo_changes[-1].tempo:
                     midi.tempo_changes.append(TempoChange(tempo_val, current_tick))
 

--- a/miditok/tokenizations/octuple.py
+++ b/miditok/tokenizations/octuple.py
@@ -261,7 +261,7 @@ class Octuple(MIDITokenizer):
         if self.config.use_tempos:
             for i in range(len(tokens)):
                 if tokens[i][6].split("_")[1] != "None":
-                    tempo_changes = [TempoChange(int(tokens[i][6].split("_")[1]), 0)]
+                    tempo_changes = [TempoChange(float(tokens[i][6].split("_")[1]), 0)]
                     break
 
         time_sig = TIME_SIGNATURE
@@ -308,7 +308,7 @@ class Octuple(MIDITokenizer):
 
             # Tempo, adds a TempoChange if necessary
             if self.config.use_tempos and time_step[6].split("_")[1] != "None":
-                tempo = int(time_step[6].split("_")[1])
+                tempo = float(time_step[6].split("_")[1])
                 if tempo != tempo_changes[-1].tempo:
                     tempo_changes.append(TempoChange(tempo, current_tick))
 

--- a/miditok/tokenizations/octuple_mono.py
+++ b/miditok/tokenizations/octuple_mono.py
@@ -166,7 +166,7 @@ class OctupleMono(MIDITokenizer):
         if self.config.use_tempos:
             for i in range(len(tokens)):
                 if tokens[i][-1].split("_")[1] != "None":
-                    tempo_changes = [TempoChange(int(tokens[i][-1].split("_")[1]), 0)]
+                    tempo_changes = [TempoChange(float(tokens[i][-1].split("_")[1]), 0)]
                     break
 
         for time_step in tokens:
@@ -194,7 +194,7 @@ class OctupleMono(MIDITokenizer):
 
             # Tempo, adds a TempoChange if necessary
             if self.config.use_tempos and time_step[-1].split("_")[1] != "None":
-                tempo = int(time_step[-1].split("_")[1])
+                tempo = float(time_step[-1].split("_")[1])
                 if tempo != tempo_changes[-1].tempo:
                     tempo_changes.append(TempoChange(tempo, current_tick))
 

--- a/miditok/tokenizations/remi.py
+++ b/miditok/tokenizations/remi.py
@@ -256,7 +256,7 @@ class REMI(MIDITokenizer):
             elif token.split("_")[0] == "Tempo":
                 # If your encoding include tempo tokens, each Position token should be followed by
                 # a tempo token, but if it is not the case this method will skip this step
-                tempo = int(token.split("_")[1])
+                tempo = float(token.split("_")[1])
                 if tempo != tempo_changes[-1].tempo:
                     tempo_changes.append(TempoChange(tempo, current_tick))
             elif token.split("_")[0] == "Pitch":

--- a/miditok/tokenizations/remi_plus.py
+++ b/miditok/tokenizations/remi_plus.py
@@ -380,7 +380,7 @@ class REMIPlus(MIDITokenizer):
             elif token.split("_")[0] == "Tempo":
                 # If your encoding include tempo tokens, each Position token should be followed by
                 # a tempo token, but if it is not the case this method will skip this step
-                tempo = int(token.split("_")[1])
+                tempo = float(token.split("_")[1])
                 if tempo != tempo_changes[-1].tempo:
                     tempo_changes.append(TempoChange(tempo, current_tick))
             elif token.split("_")[0] == "TimeSig":

--- a/miditok/tokenizations/tsd.py
+++ b/miditok/tokenizations/tsd.py
@@ -354,7 +354,7 @@ class TSD(MIDITokenizer):
                 elif token.split("_")[0] == "Tempo":
                     # If your encoding include tempo tokens, each Position token should be followed by
                     # a tempo token, but if it is not the case this method will skip this step
-                    tempo = int(token.split("_")[1])
+                    tempo = float(token.split("_")[1])
                     if tempo != tempo_changes[-1].tempo:
                         tempo_changes.append(TempoChange(tempo, current_tick))
                 elif token.split("_")[0] == "TimeSig":


### PR DESCRIPTION
Hi! This PR adds support for log scale tempos in addition to the existing linear scale tempos. Log scale tempos are used by [MusicBERT](https://github.com/microsoft/muzic/tree/main/musicbert) and maybe some other works.

I made the tempo values as rounded floats because rounding to integers can result in repeated values for certain configurations (low `min_tempo` and large `nb_tempos`) and loss of precision for differences/ratios between neighbouring values.