### PR TITLE
Update time signature tokens configuration

### DIFF
--- a/miditok/classes.py
+++ b/miditok/classes.py
@@ -183,7 +183,8 @@ class TokenizerConfig:
     :param nb_tempos: number of tempos "bins" to use. (default: 32)
     :param tempo_range: range of minimum and maximum tempos within which the bins fall. (default: (40, 250))
     :param log_tempos: will use log scaled tempo values instead of linearly scaled. (default: False)
-    :param time_signature_range: range as a tuple (max_beat_res, nb_notes). (default: (8, 2))
+    :param time_signature_range: range as a dictionary {denom_i: [num_i1, ..., num_in] / (min_num_i, max_num_i)}.
+            (default: {4: [4]})
     :param programs: sequence of MIDI programs to use. Note that `-1` is used and reserved for drums tracks.
             (default: from -1 to 127 included)
     :param **kwargs: additional parameters that will be saved in `config.additional_params`.
@@ -207,7 +208,7 @@ class TokenizerConfig:
         nb_tempos: int = NB_TEMPOS,
         tempo_range: Tuple[int, int] = TEMPO_RANGE,
         log_tempos: bool = LOG_TEMPOS,
-        time_signature_range: Tuple[int, int] = TIME_SIGNATURE_RANGE,
+        time_signature_range: Dict[int, Union[List[int], Tuple[int, int]]] = TIME_SIGNATURE_RANGE,
         programs: Sequence[int] = PROGRAMS,
         **kwargs,
     ):
@@ -240,7 +241,10 @@ class TokenizerConfig:
         self.log_tempos: bool = log_tempos
 
         # Time signature params
-        self.time_signature_range: Tuple[int, int] = time_signature_range
+        self.time_signature_range: Dict[int, List[int]] = {
+            beat_res: list(range(beats[0], beats[1] + 1)) if isinstance(beats, tuple) else beats
+            for beat_res, beats in time_signature_range.items()
+        }
 
         # Programs
         self.programs: Sequence[int] = programs
@@ -323,6 +327,11 @@ class TokenizerConfig:
         dict_config["beat_res"] = {
             tuple(map(int, beat_range.split("_"))): res
             for beat_range, res in dict_config["beat_res"].items()
+        }
+
+        dict_config["time_signature_range"] = {
+            int(res): beat_range
+            for res, beat_range in dict_config["time_signature_range"].items()
         }
 
         return cls.from_dict(dict_config)

--- a/miditok/constants.py
+++ b/miditok/constants.py
@@ -64,7 +64,7 @@ TEMPO_RANGE = (40, 250)  # (min_tempo, max_tempo)
 LOG_TEMPOS = False  # log or linear scale tempos
 
 # Time signature params
-TIME_SIGNATURE_RANGE = (8, 2)
+TIME_SIGNATURE_RANGE = {4: [4]}  # {denom_i: [num_i1, ..., num_in] / (min_num_i, max_num_i)}
 
 # Programs
 PROGRAMS = list(range(-1, 128))

--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -1174,9 +1174,10 @@ class MIDITokenizer(ABC):
         :param midi: MIDI file
         :return: boolean indicating whether MIDI file could be processed by the Encoding
         """
-        for time_sig in midi.time_signature_changes:
-            if (time_sig.numerator, time_sig.denominator) not in self.time_signatures:
-                return False
+        if self.config.use_time_signatures:
+            for time_sig in midi.time_signature_changes:
+                if (time_sig.numerator, time_sig.denominator) not in self.time_signatures:
+                    return False
         return True
 
     def learn_bpe(

--- a/miditok/tokenizations/cp_word.py
+++ b/miditok/tokenizations/cp_word.py
@@ -1,3 +1,4 @@
+from math import ceil
 from typing import List, Tuple, Dict, Optional, Union, Any
 
 import numpy as np
@@ -395,7 +396,8 @@ class CPWord(MIDITokenizer):
         vocab[0].append("Family_Note")
 
         # POSITION
-        nb_positions = max(self.config.beat_res.values()) * 4  # 4/* time signature
+        max_nb_beats = max(map(lambda ts: ceil(4 * ts[0] / ts[1]), self.time_signatures))
+        nb_positions = max(self.config.beat_res.values()) * max_nb_beats
         vocab[1].append("Ignore_None")
         vocab[1].append("Bar_None")
         vocab[1] += [f"Position_{i}" for i in range(nb_positions)]

--- a/miditok/tokenizations/mmm.py
+++ b/miditok/tokenizations/mmm.py
@@ -160,10 +160,7 @@ class MMM(MIDITokenizer):
         # Time events
         events.sort(key=lambda x: (x.time, self._order(x)))
         time_sig_change = self._current_midi_metadata["time_sig_changes"][0]
-        first_time_sig = self._reduce_time_signature(
-            time_sig_change.numerator, time_sig_change.denominator
-        )
-        ticks_per_bar = time_division * first_time_sig[0]
+        ticks_per_bar = self._compute_ticks_per_bar(time_sig_change, time_division)
         previous_tick = 0
         current_bar = 0
         for ei in range(len(events)):
@@ -263,7 +260,7 @@ class MMM(MIDITokenizer):
         time_signature_changes = [
             TimeSignature(*TIME_SIGNATURE, 0)
         ]  # mock the first time signature change to optimize below
-        ticks_per_bar = time_division * TIME_SIGNATURE[0]  # init
+        ticks_per_bar = self._compute_ticks_per_bar(time_signature_changes[0], time_division)  # init
 
         current_tick = 0
         current_bar = -1
@@ -314,6 +311,7 @@ class MMM(MIDITokenizer):
                     and den != current_time_signature.denominator
                 ):
                     time_signature_changes.append(TimeSignature(num, den, current_tick))
+                    # ticks_per_bar = self._compute_ticks_per_bar(time_signature_changes[-1], time_division)
             elif tok_type == "Pitch":
                 try:
                     if (

--- a/miditok/tokenizations/mumidi.py
+++ b/miditok/tokenizations/mumidi.py
@@ -410,7 +410,8 @@ class MuMIDI(MIDITokenizer):
             for i in range(*self.config.additional_params["drum_pitch_range"])
         ]
         vocab[0] += ["Bar_None"]  # new bar token
-        nb_positions = max(self.config.beat_res.values()) * 4  # 4/* time signature
+        max_nb_beats = max(map(lambda ts: ceil(4 * ts[0] / ts[1]), self.time_signatures))
+        nb_positions = max(self.config.beat_res.values()) * max_nb_beats
         vocab[0] += [f"Position_{i}" for i in range(nb_positions)]
         vocab[0] += [f"Program_{program}" for program in self.config.programs]
 

--- a/miditok/tokenizations/octuple_mono.py
+++ b/miditok/tokenizations/octuple_mono.py
@@ -233,7 +233,8 @@ class OctupleMono(MIDITokenizer):
         ]
 
         # POSITION
-        nb_positions = max(self.config.beat_res.values()) * 4  # 4/4 time signature
+        max_nb_beats = max(map(lambda ts: ceil(4 * ts[0] / ts[1]), self.time_signatures))
+        nb_positions = max(self.config.beat_res.values()) * max_nb_beats
         vocab[3] += [f"Position_{i}" for i in range(nb_positions)]
 
         # BAR

--- a/tests/benchmark_fast_bpe.py
+++ b/tests/benchmark_fast_bpe.py
@@ -25,7 +25,7 @@ ADDITIONAL_TOKENS_TEST = {
     "rest_range": (4, 16),
     "nb_tempos": 32,
     "tempo_range": (40, 250),
-    "time_signature_range": (16, 2),
+    "time_signature_range": {4: [4]},
 }
 
 

--- a/tests/test_bpe.py
+++ b/tests/test_bpe.py
@@ -26,7 +26,7 @@ TOKENIZER_PARAMS = {
     "rest_range": (4, 16),
     "nb_tempos": 32,
     "tempo_range": (40, 250),
-    "time_signature_range": (16, 2),
+    "time_signature_range": {4: [4]},
 }
 
 

--- a/tests/test_io_formats.py
+++ b/tests/test_io_formats.py
@@ -32,7 +32,7 @@ TOKENIZER_PARAMS = {
     ),  # very high value to cover every possible rest in the test files
     "nb_tempos": 32,
     "tempo_range": (40, 250),
-    "time_signature_range": (16, 2),
+    "time_signature_range": {4: [4]},
 }
 
 

--- a/tests/test_multitrack.py
+++ b/tests/test_multitrack.py
@@ -52,7 +52,7 @@ TOKENIZER_PARAMS = {
     "nb_tempos": 32,
     "tempo_range": (40, 250),
     "log_tempos": False,
-    "time_signature_range": (16, 2),
+    "time_signature_range": {4: [3, 4]},
 }
 
 

--- a/tests/test_one_track.py
+++ b/tests/test_one_track.py
@@ -40,7 +40,7 @@ TOKENIZER_PARAMS = {
     "nb_tempos": 32,
     "tempo_range": (40, 250),
     "log_tempos": True,
-    "time_signature_range": (16, 2),
+    "time_signature_range": {4: [4]},
     "chord_maps": miditok.constants.CHORD_MAPS,
     "chord_tokens_with_root_note": True,  # Tokens will look as "Chord_C:maj"
     "chord_unknown": False,

--- a/tests/test_saving_loading_config.py
+++ b/tests/test_saving_loading_config.py
@@ -17,7 +17,7 @@ ADDITIONAL_TOKENS_TEST = {
     "rest_range": (4, 16),
     "nb_tempos": 32,
     "tempo_range": (40, 250),
-    "time_signature_range": (16, 2),
+    "time_signature_range": {4: [4]},
 }
 tokenizations = [
     "MIDILike",


### PR DESCRIPTION
This PR:
* changes `time_signature_range` into a dictionary `{denom_i: [num_i1, ..., num_in] / (min_num_i, max_num_i)}`;
* `MIDITokenizer`: remove `_reduce_time_signature()` and add `validate_midi_time_signatures()` to require users to specify all needed time signatures before tokenizer construction and to allow checking if MIDI has any unsupported ones (also used in `tokenize_midi_dataset()`);
* updates tokenizers' code where time signatures and `ticks_per_bar` are computed;
* updates `time_signature_range` in test files.