### PR TITLE
Multitrack ProgramChange

### DIFF
--- a/miditok/classes.py
+++ b/miditok/classes.py
@@ -85,7 +85,20 @@ class TokSequence:
     _ids_no_bpe: List[Union[int, List[int]]] = None
 
     def __len__(self) -> int:
-        return len(self.ids)
+        if self.ids is not None:
+            return len(self.ids)
+        elif self.tokens is not None:
+            return len(self.tokens)
+        elif self.events is not None:
+            return len(self.events)
+        elif self.bytes is not None:
+            return len(self.bytes)
+        elif self._ids_no_bpe is not None:
+            return len(self._ids_no_bpe)
+        else:
+            raise ValueError(
+                "This TokSequence seems to not be initialized, all its attributes are None."
+            )
 
     def __getitem__(self, item):
         if self.ids is not None:
@@ -99,7 +112,7 @@ class TokSequence:
         elif self._ids_no_bpe is not None:
             return self._ids_no_bpe[item]
         else:
-            return ValueError(
+            raise ValueError(
                 "This TokSequence seems to not be initialized, all its attributes are None."
             )
 

--- a/miditok/constants.py
+++ b/miditok/constants.py
@@ -2,7 +2,7 @@
 
 """
 
-CURRENT_VERSION_PACKAGE = "2.1.5"  # used when saving the config of a tokenizer
+CURRENT_VERSION_PACKAGE = "2.1.6"  # used when saving the config of a tokenizer
 
 MIDI_FILES_EXTENSIONS = [".mid", ".midi", ".MID", ".MIDI"]
 
@@ -80,6 +80,7 @@ PITCH_BEND_RANGE = (-8192, 8191, 32)
 # Programs
 PROGRAMS = list(range(-1, 128))
 ONE_TOKEN_STREAM_FOR_PROGRAMS = True
+PROGRAM_CHANGES = False
 
 
 # Tokenizers specific parameters

--- a/miditok/tokenizations/cp_word.py
+++ b/miditok/tokenizations/cp_word.py
@@ -38,6 +38,7 @@ class CPWord(MIDITokenizer):
     def _tweak_config_before_creating_voc(self):
         self.config.use_sustain_pedals = False
         self.config.use_pitch_bends = False
+        self.config.program_changes = False
         token_types = ["Family", "Position", "Pitch", "Velocity", "Duration"]
         for add_tok_attr, add_token in [
             ("use_programs", "Program"),

--- a/miditok/tokenizations/midi_like.py
+++ b/miditok/tokenizations/midi_like.py
@@ -479,6 +479,8 @@ class MIDILike(MIDITokenizer):
                     dic["PedalOff"].append("Rest")
             if self.config.use_pitch_bends:
                 dic["Rest"].append("PitchBend")
+        else:
+            dic["TimeShift"].append("TimeShift")
 
         if self.config.program_changes:
             for token_type in [

--- a/miditok/tokenizations/midi_like.py
+++ b/miditok/tokenizations/midi_like.py
@@ -165,16 +165,19 @@ class MIDILike(MIDITokenizer):
         assert (
             time_division % max(self.config.beat_res.values()) == 0
         ), f"Invalid time division, please give one divisible by {max(self.config.beat_res.values())}"
-        ticks_per_sample = time_division // max(self.config.beat_res.values())
-        max_duration = self.durations[-1][0] * time_division + self.durations[-1][1] * (
-            time_division // self.durations[-1][2]
-        )
+        if time_division in self._durations_ticks:
+            max_duration_tok_tick = max(self._durations_ticks[time_division])
+        else:
+            max_duration_tok_tick = self._token_duration_to_ticks(
+                self.durations[-1], time_division
+            )
 
         # RESULTS
         instruments: Dict[int, Instrument] = {}
         tempo_changes = [TempoChange(TEMPO, -1)]
         time_signature_changes = [TimeSignature(*TIME_SIGNATURE, 0)]
         active_pedals = {}
+        active_notes = {p: {} for p in self.config.programs}
 
         def check_inst(prog: int):
             if prog not in instruments.keys():
@@ -186,12 +189,10 @@ class MIDILike(MIDITokenizer):
 
         current_tick = 0
         current_program = 0
-        previous_note_end = 0
         for si, seq in enumerate(tokens):
             # Set track / sequence program if needed
             if not self.one_token_stream:
                 current_tick = 0
-                previous_note_end = 0
                 if programs is not None:
                     current_program = -1 if programs[si][1] else programs[si][0]
 
@@ -199,66 +200,28 @@ class MIDILike(MIDITokenizer):
             for ti, token in enumerate(seq):
                 tok_type, tok_val = token.split("_")
                 if tok_type in ["TimeShift", "Rest"]:
-                    if tok_type == "Rest":
-                        current_tick = max(previous_note_end, current_tick)
                     current_tick += self._token_duration_to_ticks(
                         tok_val, time_division
                     )
-                elif tok_type == "NoteOn":
-                    try:
-                        if seq[ti + 1].split("_")[0] == "Velocity":
-                            pitch = int(seq[ti].split("_")[1])
-                            vel = int(seq[ti + 1].split("_")[1])
-
-                            # look for an associated note off event to get duration
-                            offset_tick = 0
-                            duration = 0
-                            noff_program = None
-                            for i in range(ti + 1, len(seq)):
-                                tok_type, tok_val = seq[i].split("_")
-                                if tok_type == "Program":
-                                    noff_program = int(tok_val)
-                                elif tok_type == "NoteOff" and int(tok_val) == pitch:
-                                    good_noff = True
-                                    if self.config.use_programs:
-                                        if not (
-                                            noff_program is not None
-                                            and noff_program == current_program
-                                        ):
-                                            good_noff = False
-                                    if good_noff:
-                                        duration = offset_tick
-                                        break
-
-                                elif tok_type == "TimeShift":
-                                    offset_tick += self._token_duration_to_ticks(
-                                        tok_val, time_division
-                                    )
-                                elif tok_type == "Rest":
-                                    offset_tick += self._token_duration_to_ticks(tok_val, time_division)
-                                if (
-                                    offset_tick > max_duration
-                                ):  # will not look for Note Off beyond
-                                    break
-
-                            if duration == 0 and default_duration is not None:
-                                duration = default_duration
-                            if duration != 0:
-                                check_inst(current_program)
-                                instruments[current_program].notes.append(
-                                    Note(
-                                        vel,
-                                        pitch,
-                                        current_tick,
-                                        current_tick + duration,
-                                    )
-                                )
-                                previous_note_end = max(
-                                    previous_note_end, current_tick + duration
-                                )
-                    except IndexError:
-                        continue
-
+                elif tok_type in ["NoteOn", "NoteOff"]:
+                    pitch = int(tok_val)
+                    # if NoteOn and already active, end the active note here, but this shouldn't happen
+                    if pitch in active_notes[current_program]:
+                        note_onset_tick, vel = active_notes[current_program][pitch]
+                        offset_tick = current_tick
+                        if current_tick - note_onset_tick > max_duration_tok_tick:
+                            if default_duration is not None:
+                                offset_tick = note_onset_tick + default_duration
+                            else:
+                                continue
+                        check_inst(current_program)
+                        instruments[current_program].notes.append(
+                            Note(vel, pitch, note_onset_tick, offset_tick)
+                        )
+                        del active_notes[current_program][pitch]
+                    if tok_type == "NoteOn" and ti + 1 < len(seq):
+                        vel = int(seq[ti + 1].split("_")[1])
+                        active_notes[current_program][pitch] = (current_tick, vel)
                 elif tok_type == "Program":
                     current_program = int(tok_val)
                 elif tok_type == "Tempo":
@@ -267,7 +230,6 @@ class MIDILike(MIDITokenizer):
                     tempo = float(tok_val)
                     if si == 0 and current_tick != tempo_changes[-1].time:
                         tempo_changes.append(TempoChange(tempo, current_tick))
-                    previous_note_end = max(previous_note_end, current_tick)
                 elif si == 0 and tok_type == "TimeSig":
                     num, den = self._parse_token_time_signature(tok_val)
                     current_time_signature = time_signature_changes[-1]
@@ -311,6 +273,14 @@ class MIDILike(MIDITokenizer):
                         check_inst(current_program)
                     instruments[current_program].pitch_bends.append(
                         PitchBend(int(tok_val), current_tick)
+                    )
+        # Handle notes still active
+        if default_duration is not None:
+            for program, active_notes_ in active_notes.items():
+                for pitch, (onset_tick, vel) in active_notes_.items():
+                    check_inst(program)
+                    instruments[program].notes.append(
+                        Note(vel, pitch, onset_tick, onset_tick + default_duration)
                     )
         if len(tempo_changes) > 1:
             del tempo_changes[0]  # delete mocked tempo change
@@ -389,7 +359,9 @@ class MIDILike(MIDITokenizer):
         dic["NoteOn"] = ["Velocity"]
 
         if self.config.use_programs:
-            first_note_token_type = "NoteOn" if self.config.program_changes else "Program"
+            first_note_token_type = (
+                "NoteOn" if self.config.program_changes else "Program"
+            )
             dic["Program"] = ["NoteOn", "NoteOff"]
         else:
             first_note_token_type = "NoteOn"
@@ -397,7 +369,7 @@ class MIDILike(MIDITokenizer):
         dic["NoteOff"] = ["NoteOff", first_note_token_type, "TimeShift"]
         dic["TimeShift"] = ["NoteOff", first_note_token_type]
         if self.config.program_changes:
-            for token_type in ["Velocity", "NoteOn", "NoteOff"]:
+            for token_type in ["Velocity", "NoteOff"]:
                 dic[token_type].append("Program")
 
         if self.config.use_chords:
@@ -410,6 +382,8 @@ class MIDILike(MIDITokenizer):
         if self.config.use_tempos:
             dic["TimeShift"] += ["Tempo"]
             dic["Tempo"] = [first_note_token_type, "TimeShift"]
+            if not self.config.use_programs or self.config.program_changes:
+                dic["Tempo"].append("NoteOff")
             if self.config.use_chords:
                 dic["Tempo"] += ["Chord"]
             if self.config.use_rests:
@@ -418,6 +392,8 @@ class MIDILike(MIDITokenizer):
         if self.config.use_time_signatures:
             dic["TimeShift"] += ["TimeSig"]
             dic["TimeSig"] = [first_note_token_type, "TimeShift"]
+            if not self.config.use_programs or self.config.program_changes:
+                dic["TimeSig"].append("NoteOff")
             if self.config.use_chords:
                 dic["TimeSig"] += ["Chord"]
             if self.config.use_rests:
@@ -427,6 +403,9 @@ class MIDILike(MIDITokenizer):
 
         if self.config.use_sustain_pedals:
             dic["TimeShift"].append("Pedal")
+            dic["NoteOff"].append("Pedal")
+            if not self.config.sustain_pedal_duration:
+                dic["NoteOff"].append("PedalOff")
             if self.config.sustain_pedal_duration:
                 dic["Pedal"] = ["Duration"]
                 dic["Duration"] = [first_note_token_type, "NoteOff", "TimeShift"]
@@ -462,8 +441,11 @@ class MIDILike(MIDITokenizer):
             # As a Program token will precede PitchBend otherwise
             # Else no need to add Program as its already in
             dic["PitchBend"] = [first_note_token_type, "NoteOff", "TimeShift"]
-            if not self.config.use_programs:
+            if self.config.use_programs:
+                dic["Program"].append("PitchBend")
+            if not self.config.programs or self.config.program_changes:
                 dic["TimeShift"].append("PitchBend")
+                dic["NoteOff"].append("PitchBend")
                 if self.config.use_tempos:
                     dic["Tempo"].append("PitchBend")
                 if self.config.use_time_signatures:
@@ -474,8 +456,6 @@ class MIDILike(MIDITokenizer):
                         dic["Duration"].append("PitchBend")
                     else:
                         dic["PedalOff"].append("PitchBend")
-            else:
-                dic["Program"].append("PitchBend")
             if self.config.use_chords:
                 dic["PitchBend"].append("Chord")
             if self.config.use_rests:
@@ -501,7 +481,16 @@ class MIDILike(MIDITokenizer):
                 dic["Rest"].append("PitchBend")
 
         if self.config.program_changes:
-            for token_type in ["TimeShift", "Rest", "PitchBend", "Pedal", "PedalOff", "Tempo", "TimeSig", "Chord"]:
+            for token_type in [
+                "TimeShift",
+                "Rest",
+                "PitchBend",
+                "Pedal",
+                "PedalOff",
+                "Tempo",
+                "TimeSig",
+                "Chord",
+            ]:
                 if token_type in dic:
                     dic["Program"].append(token_type)
                     dic[token_type].append("Program")
@@ -533,7 +522,7 @@ class MIDILike(MIDITokenizer):
         # Override from here
 
         err = 0
-        current_program = noff_program = 0
+        current_program = 0
         current_pitches = {p: [] for p in self.config.programs}
         current_pitches_tick = {p: [] for p in self.config.programs}
         max_duration = self.durations[-1][0] * max(self.config.beat_res.values())
@@ -565,32 +554,31 @@ class MIDILike(MIDITokenizer):
                         if events[j].type == "NoteOff" and int(events[j].value) == int(
                             events[i].value
                         ):
-                            if self.config.use_programs and current_program_noff == current_program:
-                                    break  # all good
+                            if (
+                                self.config.use_programs
+                                and current_program_noff == current_program
+                            ):
+                                break  # all good
                             else:
                                 break  # all good
-                        elif events[j].type == "TimeShift":
+                        elif events[j].type in ["TimeShift", "Rest"]:
                             offset_sample += self._token_duration_to_ticks(
                                 events[j].value, max(self.config.beat_res.values())
                             )
                         elif events[j].type == "Program":
                             current_program_noff = events[j].value
 
-                        if (
-                            offset_sample > max_duration
-                        ):  # will not look for Note Off beyond
+                        # will not look for Note Off beyond
+                        if offset_sample > max_duration:
                             err += 1
                             break
                 elif events[i].type == "NoteOff":
-                    if int(events[i].value) not in current_pitches[noff_program]:
+                    if int(events[i].value) not in current_pitches[current_program]:
                         err += 1  # this pitch wasn't being played
                     else:
-                        current_pitches[noff_program].remove(int(events[i].value))
+                        current_pitches[current_program].remove(int(events[i].value))
                 elif events[i].type == "Program" and i + 1 < len(events):
-                    if events[i + 1].type == "NoteOff":
-                        noff_program = int(events[i].value)
-                    else:
-                        current_program = int(events[i].value)
+                    current_program = int(events[i].value)
                 elif events[i].type in ["TimeShift", "Rest"]:
                     current_pitches_tick = {p: [] for p in self.config.programs}
 

--- a/miditok/tokenizations/mmm.py
+++ b/miditok/tokenizations/mmm.py
@@ -34,6 +34,7 @@ class MMM(MIDITokenizer):
 
     def _tweak_config_before_creating_voc(self):
         self.config.one_token_stream_for_programs = True
+        self.config.program_changes = False
         self.config.use_programs = True
         self.config.use_rests = False
         self.config.use_sustain_pedals = False

--- a/miditok/tokenizations/mumidi.py
+++ b/miditok/tokenizations/mumidi.py
@@ -52,6 +52,7 @@ class MuMIDI(MIDITokenizer):
         self.config.use_pitch_bends = False
         self.config.use_programs = True
         self.config.one_token_stream_for_programs = True
+        self.config.program_changes = False
 
         if "drum_pitch_range" not in self.config.additional_params:
             self.config.additional_params["drum_pitch_range"] = DRUM_PITCH_RANGE

--- a/miditok/tokenizations/octuple.py
+++ b/miditok/tokenizations/octuple.py
@@ -384,7 +384,9 @@ class Octuple(MIDITokenizer):
         return {}  # not relevant for Octuple
 
     @_in_as_seq()
-    def tokens_errors(self, tokens: Union[TokSequence, List, np.ndarray, Any]) -> float:
+    def tokens_errors(
+        self, tokens: Union[TokSequence, List, np.ndarray, Any]
+    ) -> Union[float, List[float]]:
         r"""Checks if a sequence of tokens is made of good token values and
         returns the error ratio (lower is better).
         The token types are always the same in Octuple so this methods only checks
@@ -396,6 +398,10 @@ class Octuple(MIDITokenizer):
         :param tokens: sequence of tokens to check
         :return: the error ratio (lower is better)
         """
+        # If list of TokSequence -> recursive
+        if isinstance(tokens, list):
+            return [self.tokens_errors(tok_seq) for tok_seq in tokens]
+
         err = 0
         current_bar = current_pos = -1
         current_pitches = {p: [] for p in self.config.programs}

--- a/miditok/tokenizations/octuple.py
+++ b/miditok/tokenizations/octuple.py
@@ -49,6 +49,7 @@ class Octuple(MIDITokenizer):
         self.config.use_sustain_pedals = False
         self.config.use_pitch_bends = False
         self.config.delete_equal_successive_tempo_changes = True
+        self.config.program_changes = False
 
         # used in place of positional encoding
         # This attribute might increase over tokenizations, if the tokenizer encounter longer MIDIs

--- a/miditok/tokenizations/remi.py
+++ b/miditok/tokenizations/remi.py
@@ -537,8 +537,6 @@ class REMI(MIDITokenizer):
                     dic["PedalOff"].append("Rest")
             if self.config.use_pitch_bends:
                 dic["Rest"].append("PitchBend")
-        else:
-            dic["TimeShift"].append("TimeShift")
 
         if self.config.program_changes:
             for token_type in [

--- a/miditok/tokenizations/remi.py
+++ b/miditok/tokenizations/remi.py
@@ -537,6 +537,8 @@ class REMI(MIDITokenizer):
                     dic["PedalOff"].append("Rest")
             if self.config.use_pitch_bends:
                 dic["Rest"].append("PitchBend")
+        else:
+            dic["TimeShift"].append("TimeShift")
 
         if self.config.program_changes:
             for token_type in [

--- a/miditok/tokenizations/structured.py
+++ b/miditok/tokenizations/structured.py
@@ -36,6 +36,7 @@ class Structured(MIDITokenizer):
         self.config.use_time_signatures = False
         self.config.use_sustain_pedals = False
         self.config.use_pitch_bends = False
+        self.config.program_changes = False
 
     def _create_track_events(self, track: Instrument) -> List[Event]:
         r"""Extract the tokens / events of individual tracks: `Pitch`, `Velocity`, `Duration`, `NoteOn`, `NoteOff` and

--- a/miditok/tokenizations/tsd.py
+++ b/miditok/tokenizations/tsd.py
@@ -431,6 +431,8 @@ class TSD(MIDITokenizer):
                     dic["PedalOff"].append("Rest")
             if self.config.use_pitch_bends:
                 dic["Rest"].append("PitchBend")
+        else:
+            dic["TimeShift"].append("TimeShift")
 
         if self.config.program_changes:
             for token_type in [

--- a/miditok/tokenizations/tsd.py
+++ b/miditok/tokenizations/tsd.py
@@ -138,7 +138,6 @@ class TSD(MIDITokenizer):
         assert (
             time_division % max(self.config.beat_res.values()) == 0
         ), f"Invalid time division, please give one divisible by {max(self.config.beat_res.values())}"
-        ticks_per_sample = time_division // max(self.config.beat_res.values())
 
         # RESULTS
         instruments: Dict[int, Instrument] = {}
@@ -322,7 +321,9 @@ class TSD(MIDITokenizer):
         dic = dict()
 
         if self.config.use_programs:
-            first_note_token_type = "Program"
+            first_note_token_type = (
+                "Pitch" if self.config.program_changes else "Program"
+            )
             dic["Program"] = ["Pitch"]
         else:
             first_note_token_type = "Pitch"
@@ -330,6 +331,8 @@ class TSD(MIDITokenizer):
         dic["Velocity"] = ["Duration"]
         dic["Duration"] = [first_note_token_type, "TimeShift"]
         dic["TimeShift"] = [first_note_token_type]
+        if self.config.program_changes:
+            dic["Duration"].append("Program")
 
         if self.config.use_chords:
             dic["Chord"] = [first_note_token_type]
@@ -391,7 +394,9 @@ class TSD(MIDITokenizer):
             # As a Program token will precede PitchBend otherwise
             # Else no need to add Program as its already in
             dic["PitchBend"] = [first_note_token_type, "TimeShift"]
-            if not self.config.use_programs:
+            if self.config.use_programs:
+                dic["Program"].append("PitchBend")
+            if not self.config.programs or self.config.program_changes:
                 dic["TimeShift"].append("PitchBend")
                 if self.config.use_tempos:
                     dic["Tempo"].append("PitchBend")
@@ -403,8 +408,6 @@ class TSD(MIDITokenizer):
                         dic["Duration"].append("PitchBend")
                     else:
                         dic["PedalOff"].append("PitchBend")
-            else:
-                dic["Program"].append("PitchBend")
             if self.config.use_chords:
                 dic["PitchBend"].append("Chord")
             if self.config.use_rests:
@@ -428,5 +431,20 @@ class TSD(MIDITokenizer):
                     dic["PedalOff"].append("Rest")
             if self.config.use_pitch_bends:
                 dic["Rest"].append("PitchBend")
+
+        if self.config.program_changes:
+            for token_type in [
+                "TimeShift",
+                "Rest",
+                "PitchBend",
+                "Pedal",
+                "PedalOff",
+                "Tempo",
+                "TimeSig",
+                "Chord",
+            ]:
+                if token_type in dic:
+                    dic["Program"].append(token_type)
+                    dic[token_type].append("Program")
 
         return dic

--- a/miditok/utils/utils.py
+++ b/miditok/utils/utils.py
@@ -94,6 +94,7 @@ def detect_chords(
     notes: Sequence[Note],
     time_division: int,
     chord_maps: Dict[str, Sequence[int]],
+    program: int = None,
     specify_root_note: bool = True,
     beat_res: int = 4,
     onset_offset: int = 1,
@@ -113,6 +114,8 @@ def detect_chords(
     :param chord_maps: list of chord maps, to be given as a dictionary where keys are chord qualities
             (e.g. "maj") and values pitch maps as tuples of integers (e.g. (0, 4, 7)).
             You can use ``miditok.constants.CHORD_MAPS`` as an example.
+    :param program: program of the track of the notes. Used to specify the program when creating the Event object.
+            (default: None)
     :param specify_root_note: the root note of each chord will be specified in Events / tokens.
             Tokens will look as "Chord_C:maj". (default: True)
     :param beat_res: beat resolution, i.e. nb of samples per beat (default 4).
@@ -187,6 +190,7 @@ def detect_chords(
                         type="Chord",
                         value=chord_quality,
                         time=min(chord[:, 1]),
+                        program=program,
                         desc=chord_map,
                     )
                 )

--- a/miditok/utils/utils.py
+++ b/miditok/utils/utils.py
@@ -33,6 +33,13 @@ def convert_ids_tensors_to_list(ids: Any):
                 "The tokens must be given as a list of integers, np.ndarray, or PyTorch / Tensorflow tensor"
             )
         ids = ids.astype(int).tolist()
+    else:
+        # Recursively checks the content are ints (only check first item)
+        el = ids[0]
+        while isinstance(el, list):
+            el = el[0]
+        if not isinstance(el, int):
+            raise TypeError
 
     return ids
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author="Nathan Fradet",
     url="https://github.com/Natooz/MidiTok",
     packages=find_packages(exclude=("tests",)),
-    version="2.1.5",
+    version="2.1.6",
     license="MIT",
     description="A convenient MIDI tokenizer for Deep Learning networks, with multiple encoding strategies",
     long_description=long_description,

--- a/tests/test_multitrack.py
+++ b/tests/test_multitrack.py
@@ -42,6 +42,7 @@ TOKENIZER_PARAMS = {
     "log_tempos": False,
     "time_signature_range": {4: [3, 4]},
     "sustain_pedal_duration": False,
+    "program_changes": False,
 }
 
 
@@ -57,6 +58,7 @@ def test_multitrack_midi_to_tokens_to_midi(
     files = list(Path(data_path).glob("**/*.mid"))
     has_errors = False
     t0 = time()
+    # TODO test with and without program change
 
     for i, file_path in enumerate(tqdm(files, desc="Testing multitrack")):
         # Reads the MIDI
@@ -109,6 +111,9 @@ def test_multitrack_midi_to_tokens_to_midi(
                 time_division=midi_to_compare.ticks_per_beat,
             )
             new_midi.instruments.sort(key=lambda x: (x.program, x.is_drum))
+            if tokenization == "MIDILike":
+                for track in new_midi.instruments:
+                    track.notes.sort(key=lambda x: (x.start, x.pitch, x.end))
 
             # Checks types and values conformity following the rules
             tokens_types = tokenizer.tokens_errors(

--- a/tests/test_one_track.py
+++ b/tests/test_one_track.py
@@ -33,7 +33,7 @@ TOKENIZER_PARAMS = {
     "use_time_signatures": True,
     "use_sustain_pedals": True,
     "use_pitch_bends": True,
-    "use_programs": False,
+    "use_programs": True,
     "beat_res_rest": {(0, 2): 4, (2, 12): 2},
     "nb_tempos": 32,
     "tempo_range": (40, 250),
@@ -45,6 +45,8 @@ TOKENIZER_PARAMS = {
     "delete_equal_successive_time_sig_changes": True,
     "delete_equal_successive_tempo_changes": True,
     "sustain_pedal_duration": True,
+    "one_token_stream_for_programs": False,
+    "program_changes": True,
 }
 
 
@@ -133,6 +135,8 @@ def test_one_track_midi_to_tokens_to_midi(
             )
             track = new_midi.instruments[0]
             track.name = f"encoded with {tokenization}"
+            if tokenization == "MIDILike":
+                track.notes.sort(key=lambda x: (x.start, x.pitch, x.end))
 
             # Checks its good
             errors = track_equals(midi_to_compare.instruments[0], track)


### PR DESCRIPTION
Following #71, this PR adds the option (`config.program_changes`) to use `Program` tokens similarly to the way the MIDI `Program Change` messages occur.

The option only works for `TSD`, `REMI` and `MIDILike` as multi-voc tokenizers will gather the Program information with the note tokens, program changes would break `Structured`'s recurrent token type succession, and `MMM` already separate the tracks within the token sequence.

Still a few things to check, and enforce the multitrack tests