### PR TITLE
Fixing time signature error for REMI and CPWord (first TS at tick 0)

### DIFF
--- a/docs/tokenizations.rst
+++ b/docs/tokenizations.rst
@@ -107,7 +107,6 @@ MMM
 Create yours
 ------------------------
 
-You can easily create your own tokenization and benefit from the MidiTok framework. Just create a class inheriting from :class:`miditok.MIDITokenizer`, and override the :py:func:`miditok.MIDITokenizer._add_time_events`, :py:func:`miditok.MIDITokenizer.tokens_to_midi` / :py:func:`miditok.MIDITokenizer.tokens_to_track`, :py:func:`miditok.MIDITokenizer._create_vocabulary` and :py:func:`miditok.MIDITokenizer._create_token_types_graph` (and optionally :py:func:`miditok.MIDITokenizer._midi_to_tokens`, :py:func:`miditok.MIDITokenizer._create_track_events` and :py:func:`miditok.MIDITokenizer._create_midi_events`) methods with your tokenization strategy.
+You can easily create your own tokenization and benefit from the MidiTok framework. Just create a class inheriting from :class:`miditok.MIDITokenizer`, and override the :py:func:`miditok.MIDITokenizer._add_time_events`, :py:func:`miditok.MIDITokenizer.tokens_to_midi`, :py:func:`miditok.MIDITokenizer._create_vocabulary` and :py:func:`miditok.MIDITokenizer._create_token_types_graph` (and optionally if needed :py:func:`miditok.MIDITokenizer._midi_to_tokens`, :py:func:`miditok.MIDITokenizer._create_track_events` and :py:func:`miditok.MIDITokenizer._create_midi_events`) methods with your tokenization strategy.
 
-We encourage you to read the documentation of the :ref:`Vocabulary` class to learn how to use it for your tokenization.
 If you think people can benefit from it, feel free to send a pull request on `Github <https://github.com/Natooz/MidiTok>`_.

--- a/miditok/tokenizations/cp_word.py
+++ b/miditok/tokenizations/cp_word.py
@@ -76,6 +76,18 @@ class CPWord(MIDITokenizer):
         ticks_per_bar = self._compute_ticks_per_bar(
             TimeSignature(*current_time_sig, 0), time_division
         )
+        # First look for a TimeSig token, if any is given at tick 0, to update current_time_sig
+        if self.config.use_time_signatures:
+            for event in events:
+                if event.type == "TimeSig":
+                    current_time_sig = list(map(int, event.value.split("/")))
+                    ticks_per_bar = self._compute_ticks_per_bar(
+                        TimeSignature(*current_time_sig, event.time), time_division
+                    )
+                    break
+                elif event.type in ["Pitch", "Velocity", "Duration", "PitchBend", "Pedal"]:
+                    break
+        # Add the time events
         for e, event in enumerate(events):
             if event.type == "TimeSig":
                 current_time_sig = list(map(int, event.value.split("/")))

--- a/miditok/tokenizations/remi.py
+++ b/miditok/tokenizations/remi.py
@@ -92,6 +92,18 @@ class REMI(MIDITokenizer):
         ticks_per_bar = self._compute_ticks_per_bar(
             TimeSignature(*current_time_sig, 0), time_division
         )
+        # First look for a TimeSig token, if any is given at tick 0, to update current_time_sig
+        if self.config.use_time_signatures:
+            for event in events:
+                if event.type == "TimeSig":
+                    current_time_sig = list(map(int, event.value.split("/")))
+                    ticks_per_bar = self._compute_ticks_per_bar(
+                        TimeSignature(*current_time_sig, event.time), time_division
+                    )
+                    break
+                elif event.type in ["Pitch", "Velocity", "Duration", "PitchBend", "Pedal"]:
+                    break
+        # Add the time events
         for e, event in enumerate(events):
             if event.type == "TimeSig":
                 current_time_sig = list(map(int, event.value.split("/")))

--- a/tests/test_one_track.py
+++ b/tests/test_one_track.py
@@ -69,7 +69,6 @@ def test_one_track_midi_to_tokens_to_midi(
         tracks_with_errors = []
 
         for tokenization in ALL_TOKENIZATIONS:
-            has_errors = False
             params = deepcopy(TOKENIZER_PARAMS)
             # Special beat res for test, up to 64 beats so the duration and time-shift values are
             # long enough for Structured, and with a single beat resolution


### PR DESCRIPTION
Following #73, this PR fixes a bug in `REMI` and `CPWord` where the first Time Signature (when at tick 0) was ignored and replaced by the default one (4/4).