### PR TITLE
tokenize_midi_dataset reproducing source file tree, overwrite_mode

### DIFF
--- a/miditok/__init__.py
+++ b/miditok/__init__.py
@@ -12,7 +12,11 @@ from .tokenizations import (
 )
 
 from .utils import utils
+from .constants import CURRENT_VERSION_PACKAGE
 from miditok import data_augmentation
+
+
+__version__ = CURRENT_VERSION_PACKAGE
 
 
 class REMIPlus(REMI):

--- a/miditok/constants.py
+++ b/miditok/constants.py
@@ -2,7 +2,7 @@
 
 """
 
-CURRENT_VERSION_PACKAGE = "2.1.6"  # used when saving the config of a tokenizer
+CURRENT_VERSION_PACKAGE = "2.1.7"  # used when saving the config of a tokenizer
 
 MIDI_FILES_EXTENSIONS = [".mid", ".midi", ".MID", ".MIDI"]
 

--- a/miditok/data_augmentation/data_augmentation.py
+++ b/miditok/data_augmentation/data_augmentation.py
@@ -140,6 +140,7 @@ def data_augmentation_dataset(
                         if offset != 0
                     ]
                 )
+                # TODO reproduce file tree if out_path
                 saving_path = (
                     file_path.parent if out_path is None else out_path
                 ) / f"{file_path.stem}{suffix}.json"

--- a/miditok/data_augmentation/data_augmentation.py
+++ b/miditok/data_augmentation/data_augmentation.py
@@ -143,7 +143,7 @@ def data_augmentation_dataset(
                 if out_path is None:
                     saving_path = file_path.parent
                 else:
-                    saving_path = out_path / file_path.relative_to(data_path)
+                    saving_path = out_path / file_path.parent.relative_to(data_path)
                     saving_path.mkdir(parents=True, exist_ok=True)
                 saving_path /= f"{file_path.stem}{suffix}.json"
                 tokenizer.save_tokens(tracks_seq, saving_path, programs)
@@ -196,7 +196,7 @@ def data_augmentation_dataset(
                 if out_path is None:
                     saving_path = file_path.parent
                 else:
-                    saving_path = out_path / file_path.relative_to(data_path)
+                    saving_path = out_path / file_path.parent.relative_to(data_path)
                     saving_path.mkdir(parents=True, exist_ok=True)
                 saving_path /= f"{file_path.stem}{suffix}.mid"
                 aug_midi.dump(saving_path)

--- a/miditok/data_augmentation/data_augmentation.py
+++ b/miditok/data_augmentation/data_augmentation.py
@@ -1,7 +1,7 @@
 """Data augmentation methods
 
 """
-
+import warnings
 from typing import List, Tuple, Union, Dict
 from pathlib import Path
 from copy import deepcopy
@@ -31,6 +31,10 @@ def data_augmentation_dataset(
     The new created files have names in two parts, separated with a '§' character.
     Make sure your files do not have '§' in their names if you intend to reuse the information of the
     second part in some script.
+    For note duration augmentation, only the duration, i.e. the ending / offset times of the notes are altered,
+    while starting / onset times are unchanged.
+    **Note: data augmentation on note durations is not implemented at the moment for MIDI files. Duration offsets will
+    be skipped. Alternatively, you can perform data augmentation on note duration on JSON token files.**
 
     :param data_path: root path to the folder containing tokenized json files.
     :param tokenizer: tokenizer, needs to have 'Pitch' or 'NoteOn' tokens. Has to be given
@@ -340,6 +344,8 @@ def data_augmentation_midi(
 ) -> List[Tuple[Tuple[int, int, int], MidiFile]]:
     r"""Perform data augmentation on a MIDI object.
     Drum tracks are not augmented, but copied as original in augmented MIDIs.
+    **Note: data augmentation on note durations is not implemented at the moment for MIDI files. Duration offsets will
+    be skipped. Alternatively, you can perform data augmentation on note duration on JSON token files.**
 
     :param midi: midi object to augment
     :param tokenizer: tokenizer, needs to have 'Pitch' tokens.
@@ -393,9 +399,15 @@ def data_augmentation_midi(
                 )  # for already augmented midis
         augmented += augment_vel(midi, (0, 0, 0))  # for original midi
 
-    # TODO Duration augmentation
-    """if duration_offsets is not None:
-        tokenizer.durations_ticks[midi.ticks_per_beat] = np.array([(beat * res + pos) * midi.ticks_per_beat // res
+    # Duration augmentation
+    if duration_offsets is not None:
+        warnings.warn(
+            "You provided duration offsets for data augmentation on MIDI files. Data augmentation on note"
+            "durations is not implemented in MidiTok at the moment. Your duration offsets will be skipped."
+            "Alternatively, you can perform data augmentation on note duration on JSON token files."
+        )
+        # TODO implement it, and remove warning above + update doc
+        """tokenizer.durations_ticks[midi.ticks_per_beat] = np.array([(beat * res + pos) * midi.ticks_per_beat // res
                                                                            for beat, pos, res in tokenizer.durations])
         def augment_dur(midi_: MidiFile, offsets_: Tuple[int, int, int]) -> List[Tuple[Tuple[int, int, int], MidiFile]]:
             aug_ = []

--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -1778,7 +1778,7 @@ class MIDITokenizer(ABC):
             root_dir = midi_paths
             midi_paths = sum(
                 (list(midi_paths.glob(f"**/*{ext}")) for ext in MIDI_FILES_EXTENSIONS),
-                []
+                [],
             )
         # User gave a list of paths, we need to find the root / deepest common subdir
         else:

--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -1687,6 +1687,7 @@ class MIDITokenizer(ABC):
                 if out_path is not None
                 else json_path
             )
+            saving_path.parent.mkdir(parents=True, exist_ok=True)
             self.save_tokens(
                 seq, saving_path, sample["programs"] if "programs" in sample else None
             )
@@ -1776,7 +1777,8 @@ class MIDITokenizer(ABC):
                 midi_paths = Path(midi_paths)
             root_dir = midi_paths
             midi_paths = sum(
-                list(midi_paths.glob(f"**/*.{ext}")) for ext in MIDI_FILES_EXTENSIONS
+                (list(midi_paths.glob(f"**/*{ext}")) for ext in MIDI_FILES_EXTENSIONS),
+                []
             )
         # User gave a list of paths, we need to find the root / deepest common subdir
         else:

--- a/miditok/pytorch_data/collators.py
+++ b/miditok/pytorch_data/collators.py
@@ -91,8 +91,10 @@ class DataCollator:
             if y[0].dim() > 0:
                 y = y[:, 1:]
             else:
-                warnings.warn("MidiTok DataCollator: You set shift_labels=True, but provided int labels"
-                              "(for sequence classification tasks) which is suited for. Skipping label shifting.")
+                warnings.warn(
+                    "MidiTok DataCollator: You set shift_labels=True, but provided int labels"
+                    "(for sequence classification tasks) which is suited for. Skipping label shifting."
+                )
 
         # Add inputs / labels to output batch
         if x is not None:

--- a/miditok/pytorch_data/datasets.py
+++ b/miditok/pytorch_data/datasets.py
@@ -236,7 +236,12 @@ class DatasetTok(_DatasetABC):
 
         if labels is not None:
             labels = LongTensor(labels)
-        super().__init__(samples, labels, sample_key_name=sample_key_name, labels_key_name=labels_key_name)
+        super().__init__(
+            samples,
+            labels,
+            sample_key_name=sample_key_name,
+            labels_key_name=labels_key_name,
+        )
 
 
 class DatasetJsonIO(_DatasetABC):

--- a/miditok/tokenizations/cp_word.py
+++ b/miditok/tokenizations/cp_word.py
@@ -44,11 +44,13 @@ class CPWord(MIDITokenizer):
             # bars. Rests would have a maximal value corresponding to the difference between the previous event tick
             # and the tick of the next bar. However, in cases of long rests of more than one bar, we would have
             # successions of Rest --> Bar --> Rest --> Bar ... tokens.
-            warnings.warn("You are using both Time Signatures and Rests with CPWord. Be aware that this configuration"
-                          "can result in altered time, as the time signature is carried by the Bar tokens, that are"
-                          "skipped during rests. To disable this warning, you can disable either Time Signatures or"
-                          "Rests. Otherwise, you can check that your data does not have time signature changes"
-                          "occurring during rests.")
+            warnings.warn(
+                "You are using both Time Signatures and Rests with CPWord. Be aware that this configuration"
+                "can result in altered time, as the time signature is carried by the Bar tokens, that are"
+                "skipped during rests. To disable this warning, you can disable either Time Signatures or"
+                "Rests. Otherwise, you can check that your data does not have time signature changes"
+                "occurring during rests."
+            )
         self.config.use_sustain_pedals = False
         self.config.use_pitch_bends = False
         self.config.program_changes = False
@@ -172,9 +174,7 @@ class CPWord(MIDITokenizer):
                 )
                 if nb_new_bars >= 1:
                     if self.config.use_time_signatures:
-                        time_sig_arg = (
-                            f"{current_time_sig[0]}/{current_time_sig[1]}"
-                        )
+                        time_sig_arg = f"{current_time_sig[0]}/{current_time_sig[1]}"
                     else:
                         time_sig_arg = None
                     for i in range(nb_new_bars):
@@ -198,7 +198,9 @@ class CPWord(MIDITokenizer):
 
                 # Position
                 if event.type != "TimeSig":
-                    pos_index = int((event.time - tick_at_current_bar) / ticks_per_sample)
+                    pos_index = int(
+                        (event.time - tick_at_current_bar) / ticks_per_sample
+                    )
                     all_events.append(
                         self.__create_cp_token(
                             event.time,
@@ -215,8 +217,8 @@ class CPWord(MIDITokenizer):
             if event.type == "TimeSig":
                 current_time_sig = list(map(int, event.value.split("/")))
                 bar_at_last_ts_change += (
-                                                 event.time - tick_at_last_ts_change
-                                         ) // ticks_per_bar
+                    event.time - tick_at_last_ts_change
+                ) // ticks_per_bar
                 tick_at_last_ts_change = event.time
                 ticks_per_bar = self._compute_ticks_per_bar(
                     TimeSignature(*current_time_sig, event.time), time_division
@@ -396,11 +398,13 @@ class CPWord(MIDITokenizer):
                             bar_pos = compound_token[1].split("_")[0]
                             if bar_pos == "Bar":
                                 num, den = self._parse_token_time_signature(
-                                    compound_token[self.vocab_types_idx["TimeSig"]].split(
-                                        "_"
-                                    )[1]
+                                    compound_token[
+                                        self.vocab_types_idx["TimeSig"]
+                                    ].split("_")[1]
                                 )
-                                time_signature_changes.append(TimeSignature(num, den, 0))
+                                time_signature_changes.append(
+                                    TimeSignature(num, den, 0)
+                                )
                                 break
                         else:
                             break
@@ -420,7 +424,9 @@ class CPWord(MIDITokenizer):
                 current_instrument = Instrument(
                     program=current_program,
                     is_drum=is_drum,
-                    name="Drums" if current_program == -1 else MIDI_INSTRUMENTS[current_program]["name"],
+                    name="Drums"
+                    if current_program == -1
+                    else MIDI_INSTRUMENTS[current_program]["name"],
                 )
 
             # Decode tokens

--- a/miditok/tokenizations/midi_like.py
+++ b/miditok/tokenizations/midi_like.py
@@ -195,12 +195,21 @@ class MIDILike(MIDITokenizer):
                         for pitch_, (onset_tick, vel_) in active_notes_.items():
                             check_inst(program)
                             instruments[program].notes.append(
-                                Note(vel_, pitch_, onset_tick, onset_tick + default_duration)
+                                Note(
+                                    vel_,
+                                    pitch_,
+                                    onset_tick,
+                                    onset_tick + default_duration,
+                                )
                             )
                 else:
-                    for pitch_, (onset_tick, vel_) in active_notes[current_instrument.program].items():
+                    for pitch_, (onset_tick, vel_) in active_notes[
+                        current_instrument.program
+                    ].items():
                         current_instrument.notes.append(
-                            Note(vel_, pitch_, onset_tick, onset_tick + default_duration)
+                            Note(
+                                vel_, pitch_, onset_tick, onset_tick + default_duration
+                            )
                         )
 
         current_tick = 0
@@ -216,7 +225,9 @@ class MIDILike(MIDITokenizer):
                 current_instrument = Instrument(
                     program=current_program,
                     is_drum=is_drum,
-                    name="Drums" if current_program == -1 else MIDI_INSTRUMENTS[current_program]["name"],
+                    name="Drums"
+                    if current_program == -1
+                    else MIDI_INSTRUMENTS[current_program]["name"],
                 )
 
             # Decode tokens

--- a/miditok/tokenizations/mmm.py
+++ b/miditok/tokenizations/mmm.py
@@ -72,7 +72,10 @@ class MMM(MIDITokenizer):
         all_events = [Event("Bar", "Start", 0)]
 
         # Time events
-        if self.config.use_time_signatures and len(self._current_midi_metadata["time_sig_changes"]) > 0:
+        if (
+            self.config.use_time_signatures
+            and len(self._current_midi_metadata["time_sig_changes"]) > 0
+        ):
             time_sig_change = self._current_midi_metadata["time_sig_changes"][0]
         else:
             time_sig_change = TimeSignature(*TIME_SIGNATURE, 0)

--- a/miditok/tokenizations/octuple.py
+++ b/miditok/tokenizations/octuple.py
@@ -247,7 +247,9 @@ class Octuple(MIDITokenizer):
                 current_instrument = Instrument(
                     program=current_program,
                     is_drum=is_drum,
-                    name="Drums" if current_program == -1 else MIDI_INSTRUMENTS[current_program]["name"],
+                    name="Drums"
+                    if current_program == -1
+                    else MIDI_INSTRUMENTS[current_program]["name"],
                 )
 
             # Decode tokens
@@ -313,7 +315,9 @@ class Octuple(MIDITokenizer):
                         tick_at_last_ts_change += (
                             event_bar - bar_at_last_ts_change
                         ) * ticks_per_bar
-                        current_time_sig = TimeSignature(num, den, tick_at_last_ts_change)
+                        current_time_sig = TimeSignature(
+                            num, den, tick_at_last_ts_change
+                        )
                         if si == 0:
                             time_signature_changes.append(current_time_sig)
                         bar_at_last_ts_change = event_bar

--- a/miditok/tokenizations/remi.py
+++ b/miditok/tokenizations/remi.py
@@ -286,7 +286,9 @@ class REMI(MIDITokenizer):
                     for token in seq:
                         tok_type, tok_val = token.split("_")
                         if tok_type == "TimeSig":
-                            time_signature_changes.append(TimeSignature(*list(map(int, tok_val.split("/"))), 0))
+                            time_signature_changes.append(
+                                TimeSignature(*list(map(int, tok_val.split("/"))), 0)
+                            )
                             break
                         elif tok_type in [
                             "Pitch",
@@ -313,7 +315,9 @@ class REMI(MIDITokenizer):
                 current_instrument = Instrument(
                     program=current_program,
                     is_drum=is_drum,
-                    name="Drums" if current_program == -1 else MIDI_INSTRUMENTS[current_program]["name"],
+                    name="Drums"
+                    if current_program == -1
+                    else MIDI_INSTRUMENTS[current_program]["name"],
                 )
 
             # Decode tokens
@@ -354,7 +358,9 @@ class REMI(MIDITokenizer):
                             duration = self._token_duration_to_ticks(
                                 seq[ti + 2].split("_")[1], time_division
                             )
-                            new_note = Note(vel, pitch, current_tick, current_tick + duration)
+                            new_note = Note(
+                                vel, pitch, current_tick, current_tick + duration
+                            )
                             if self.one_token_stream:
                                 check_inst(current_program)
                                 instruments[current_program].notes.append(new_note)

--- a/miditok/tokenizations/structured.py
+++ b/miditok/tokenizations/structured.py
@@ -227,7 +227,9 @@ class Structured(MIDITokenizer):
                 current_instrument = Instrument(
                     program=current_program,
                     is_drum=is_drum,
-                    name="Drums" if current_program == -1 else MIDI_INSTRUMENTS[current_program]["name"],
+                    name="Drums"
+                    if current_program == -1
+                    else MIDI_INSTRUMENTS[current_program]["name"],
                 )
 
             # Decode tokens
@@ -247,7 +249,9 @@ class Structured(MIDITokenizer):
                             duration = self._token_duration_to_ticks(
                                 seq[ti + 2].split("_")[1], time_division
                             )
-                            new_note = Note(vel, pitch, current_tick, current_tick + duration)
+                            new_note = Note(
+                                vel, pitch, current_tick, current_tick + duration
+                            )
                             if self.one_token_stream:
                                 check_inst(current_program)
                                 instruments[current_program].notes.append(new_note)

--- a/miditok/tokenizations/tsd.py
+++ b/miditok/tokenizations/tsd.py
@@ -170,7 +170,9 @@ class TSD(MIDITokenizer):
                 current_instrument = Instrument(
                     program=current_program,
                     is_drum=is_drum,
-                    name="Drums" if current_program == -1 else MIDI_INSTRUMENTS[current_program]["name"],
+                    name="Drums"
+                    if current_program == -1
+                    else MIDI_INSTRUMENTS[current_program]["name"],
                 )
 
             # Decode tokens
@@ -193,7 +195,9 @@ class TSD(MIDITokenizer):
                             duration = self._token_duration_to_ticks(
                                 seq[ti + 2].split("_")[1], time_division
                             )
-                            new_note = Note(vel, pitch, current_tick, current_tick + duration)
+                            new_note = Note(
+                                vel, pitch, current_tick, current_tick + duration
+                            )
                             if self.one_token_stream:
                                 check_inst(current_program)
                                 instruments[current_program].notes.append(new_note)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     author="Nathan Fradet",
     url="https://github.com/Natooz/MidiTok",
     packages=find_packages(exclude=("tests",)),
-    version="2.1.6",
+    version="2.1.7",
     license="MIT",
     description="A convenient MIDI tokenizer for Deep Learning networks, with multiple encoding strategies",
     long_description=long_description,

--- a/tests/test_bpe.py
+++ b/tests/test_bpe.py
@@ -4,7 +4,7 @@
 """
 
 from copy import deepcopy
-from pathlib import Path, PurePath
+from pathlib import Path
 from typing import Union
 from time import time
 import random
@@ -29,9 +29,7 @@ TOKENIZER_PARAMS = {
 }
 
 
-def test_bpe_conversion(
-    data_path: Union[str, Path, PurePath] = "./tests/One_track_MIDIs"
-):
+def test_bpe_conversion(data_path: Union[str, Path] = "./tests/One_track_MIDIs"):
     r"""Reads a few MIDI files, convert them into token sequences, convert them back to MIDI files.
     The converted back MIDI files should identical to original one, expect with note starting and ending
     times quantized, and maybe a some duplicated notes removed
@@ -51,8 +49,9 @@ def test_bpe_conversion(
         tokenizer: miditok.MIDITokenizer = getattr(miditok, tokenization)(
             tokenizer_config=tokenizer_config
         )
+        # Give a str to dir for coverage
         tokenizer.tokenize_midi_dataset(
-            files, Path("tests", "test_results", tokenization)
+            str(data_path), Path("tests", "test_results", tokenization)
         )
         tokenizer.learn_bpe(
             vocab_size=len(tokenizer) + 400,

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -282,6 +282,7 @@ def test_tokenize_datasets(data_path: Union[str, Path] = Path("./tests")):
         == midi_path.relative_to(data_path).with_suffix(".test")
         for json_path, midi_path in zip(json_paths, midi_paths)
     )
+    tokenizer.tokenize_midi_dataset(midi_paths, out_path, overwrite_mode=False)
 
 
 if __name__ == "__main__":

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -5,7 +5,9 @@
 """
 
 from pathlib import Path
+from typing import Union
 import json
+import random
 
 import numpy as np
 from miditoolkit import MidiFile
@@ -261,6 +263,28 @@ def test_data_augmentation():
                             ]
 
 
+def test_tokenize_datasets(data_path: Union[str, Path] = Path("./tests")):
+    # Check the file tree is copied
+    random.seed(8)
+    midi_paths = list((data_path / "One_track_MIDIs").glob("**/*.mid")) + list(
+        (data_path / "Multitrack_MIDIs").glob("**/*.mid")
+    )
+    midi_paths = random.choices(midi_paths, k=6)
+    config = miditok.TokenizerConfig()
+    tokenizer = miditok.TSD(config)
+    out_path = Path("tests", "test_results", "file_tree")
+    tokenizer.tokenize_midi_dataset(midi_paths, out_path)
+    json_paths = list(out_path.glob("**/*.json"))
+    json_paths.sort(key=lambda x: x.stem)
+    midi_paths.sort(key=lambda x: x.stem)
+    assert all(
+        json_path.relative_to(out_path).with_suffix(".test")
+        == midi_path.relative_to(data_path).with_suffix(".test")
+        for json_path, midi_path in zip(json_paths, midi_paths)
+    )
+
+
 if __name__ == "__main__":
+    test_tokenize_datasets()
     test_convert_tensors()
     test_data_augmentation()

--- a/tests/test_pytorch_data_loading.py
+++ b/tests/test_pytorch_data_loading.py
@@ -32,8 +32,10 @@ def test_dataset_ram():
     one_track_midis_paths = list(Path("tests", "One_track_MIDIs").glob("**/*.mid"))[:3]
     tokens_os_dir = Path("tests", "multitrack_tokens_os")
     dummy_labels = {
-        label: i for i, label in
-        enumerate(set(path.name.split("_")[0] for path in one_track_midis_paths))
+        label: i
+        for i, label in enumerate(
+            set(path.name.split("_")[0] for path in one_track_midis_paths)
+        )
     }
 
     def get_labels_one_track(_: Sequence, file_path: Path) -> int:


### PR DESCRIPTION
Following #79, this PR make `tokenize_midi_dataset` reproduce the source files file tree in `out_dir`.
It also allows to handle file overwriting if files already exist in the saving path.


The file tree reproduction has also to be made for `data_augmentation_dataset`