### PR TITLE
fix in detect_chords: bad check when not using unknown chords

### DIFF
--- a/miditok/utils/utils.py
+++ b/miditok/utils/utils.py
@@ -192,7 +192,7 @@ def detect_chords(
                     break
 
             # We found a chord quality, or we specify unknown chords
-            if not (unknown_chords_nb_notes_range is not None and is_unknown_chord):
+            if unknown_chords_nb_notes_range is not None or not is_unknown_chord:
                 if specify_root_note:
                     chord_quality = (
                         f"{PITCH_CLASSES[notes[count, 0] % 12]}:{chord_quality}"


### PR DESCRIPTION
Following #77 , this PR fixes a bug in `miditok.utils.detect_chords` that raised errors when the user did not specified to use unknown chords