### PR TITLE
fix typos in python function helper texts

### DIFF
--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -601,7 +601,7 @@ class MIDITokenizer(ABC, HFHubMixin):
         gathered into a list, then the time events are added. If `one_token_stream` is true, all events of all tracks
         are treated all at once, otherwise the events of each track are treated independently.
 
-        :param midi: the MIDI objet to convert.
+        :param midi: the MIDI object to convert.
         :return: a :class:`miditok.TokSequence` if `tokenizer.one_token_stream` is true, else a list of
                 :class:`miditok.TokSequence` objects.
         """

--- a/miditok/tokenizations/midi_like.py
+++ b/miditok/tokenizations/midi_like.py
@@ -123,7 +123,7 @@ class MIDILike(MIDITokenizer):
         r"""Converts a preprocessed MIDI object to a sequence of tokens.
         Overridden to call fix_offsets_overlapping_notes before.
 
-        :param midi: the MIDI objet to convert.
+        :param midi: the MIDI object to convert.
         :return: a :class:`miditok.TokSequence` if `tokenizer.one_token_stream` is true, else a list of
                 :class:`miditok.TokSequence` objects.
         """

--- a/miditok/tokenizations/structured.py
+++ b/miditok/tokenizations/structured.py
@@ -141,7 +141,7 @@ class Structured(MIDITokenizer):
         We override the parent method to handle the "non-program" case where `TimeShift` events have already been
         added by `_notes_to_events`.
 
-        :param midi: the MIDI objet to convert.
+        :param midi: the MIDI object to convert.
         :return: a :class:`miditok.TokSequence` if `tokenizer.one_token_stream` is true, else a list of
                 :class:`miditok.TokSequence` objects.
         """

--- a/miditok/utils/utils.py
+++ b/miditok/utils/utils.py
@@ -65,7 +65,7 @@ def remove_duplicated_notes(notes: List[Note], filter_by_starting_tick: bool = T
     `notes.sort(key=lambda x: (x.start, x.pitch, x.end))`
 
     :param notes: notes to analyse
-    :param filter_by_starting_tick: will remove identical notes being played at the same onset time regarless of their
+    :param filter_by_starting_tick: will remove identical notes being played at the same onset time regardless of their
         duration / offset time. If this argument is disabled, only 100% identical notes will be deduplicated,
         i.e. with the same duration too. (default: True)
     """


### PR DESCRIPTION
This pull request fixes typos in function helper text. Following are the fixed typos:
1. objet -> object
2. regarless -> regardless

I kindly request the repository maintainers to review and merge it. Thanks! :heart: