### PR TITLE
`load_tokens` now returning `TokSequence`

### DIFF
--- a/miditok/classes.py
+++ b/miditok/classes.py
@@ -185,13 +185,13 @@ class TokSequence:
         # Start from True assumption as some attributes might be unfilled (None)
         attributes = ["tokens", "ids", "bytes", "events"]
         eq = [True for _ in attributes]
-        common_attr = False
+        one_common_attr = False
         for i, attr in enumerate(attributes):
             if getattr(self, attr) is not None and getattr(other, attr) is not None:
                 eq[i] = getattr(self, attr) == getattr(other, attr)
-                common_attr = True
+                one_common_attr = True
 
-        return all(eq) if common_attr else False
+        return one_common_attr and all(eq)
 
 
 class TokenizerConfig:


### PR DESCRIPTION
As mentioned in #137, this PR makes the `load_tokens` method automatically return `TokSequence` objects. Tests for this have been added.

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--139.org.readthedocs.build/en/139/

<!-- readthedocs-preview miditok end -->