### PR TITLE
convert chord maps back to tuples from list when loading tokenizer from a saved configuration

### DIFF
--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -2865,6 +2865,11 @@ class MIDITokenizer(ABC, HFHubMixin):
                 }
                 continue
             if key == "config":
+                if "chord_maps" in value:
+                    value["chord_maps"] = {
+                        chord_quality: tuple(chord_map)
+                        for chord_quality, chord_map in value["chord_maps"].items()
+                    }
                 for beat_res_key in ["beat_res", "beat_res_rest"]:
                     # check here for previous versions (< v2.1.5)
                     if beat_res_key in value:


### PR DESCRIPTION
Hi,

I encountered an issue with chord maps when loading a saved tokenizer configuration from a file. 

The CHORD_MAPS constant value has each chord map defined in a tuple, but after creating a tokenizer and saving the configuration, the chord maps are represented as lists (example snippet below):

```
...
"chord_maps": {
            "min": [
                0,
                3,
                7
            ],
            "maj": [
                0,
                4,
                7
            ],
...
            "9min": [
                0,
                4,
                7,
                10,
                13
            ]
        },
...
```

This is caused by [json.dump](https://github.com/Natooz/MidiTok/blob/main/miditok/midi_tokenizer.py#L2778-L2779) converting all tuples into lists. This results in the [detect_chords](https://github.com/Natooz/MidiTok/blob/main/miditok/utils/utils.py#L243-L253) function always returning ukn chord tokens, i.e. 'Chord_A:ukn3', 'Chord_E:ukn3', etc.

There are a few ways to fix this:
- Make sure when saving the tokenizer config that the chord maps remain as tuples
- After loading the tokenizer, convert chord maps back into tuples
- Convert chord maps into lists and adjusting tests and documentation wherever necessary

I've implemented the second one for this PR, as it required the least amount of work and fixes the issue.

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--141.org.readthedocs.build/en/141/

<!-- readthedocs-preview miditok end -->