### PR TITLE
can now use `MIDITokenizer.from_pretrained` similarly to `AutoTokenizer`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]  # tensorflow not supported with 3.12
         os: [ ubuntu-latest, windows-latest ]
-        include:
-          - python-version: "3.11"
-            os: macos-latest
+        #include:  # TODO uncomment when multithreading pytest-xdist is fixed (PR #142)
+        #  - python-version: "3.11"
+        #    os: macos-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ Contributions are gratefully welcomed, feel free to open an issue or send a PR i
 
 ### Todos
 
-* `AutoTokenizer` class to be used with `from_pretrained` (and `from_config`?) similar to what is implemented in the Hugging face libraries;
 * `PitchDrum` tokens for pitches of drum tracks;
 * `no_duration_drums` option, discarding duration tokens for drum notes;
 * Extend unimplemented additional tokens to all compatible tokenizations;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(Path("..").resolve()))
 project = "MidiTok"
 copyright = "2023, Nathan Fradet"  # noqa: A001
 author = "Nathan Fradet"
-release = "3.0.0"
+release = "3.0.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "miditok"
-version = "3.0.0"
+version = "3.0.1"
 description = "MIDI / symbolic music tokenizers for Deep Learning models."
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 
 [project.optional-dependencies]
 tests = [
+    "pytest==7.4.4",  # TODO remove when issue with xdist/macOS is fixed for v8
     "pytest-cov",
     "pytest-xdist[psutil]",
     "torch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
 
 [project.optional-dependencies]
 tests = [
-    "pytest==7.4.4",  # TODO remove when issue with xdist/macOS is fixed for v8
     "pytest-cov",
     "pytest-xdist[psutil]",
     "torch",

--- a/tests/test_hf_hub.py
+++ b/tests/test_hf_hub.py
@@ -1,19 +1,34 @@
 """Test the integration of the Hugging Face Hub."""
+
+from __future__ import annotations
+
 import warnings
-from pathlib import Path
 from time import sleep
+from typing import TYPE_CHECKING
 
 import pytest
 from huggingface_hub.utils._errors import HfHubHTTPError
 
-from miditok import REMI, TSD, TokenizerConfig
+import miditok
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 MAX_NUM_TRIES_HF_PUSH = 5
 NUM_SECONDS_RETRY = 8
 
+AUTO_TOKENIZER_CASES = [
+    # ("class_name", "save_path", "class_name_assert")
+    ("REMI", "rem", "REMI"),
+    ("REMI", "rem2", "TSD"),
+    ("TSD", "tsd", "TSD"),
+]
+
 
 def test_push_and_load_to_hf_hub(hf_token: str):
-    tokenizer = REMI(TokenizerConfig(num_velocities=62, pitch_range=(12, 44)))
+    tokenizer = miditok.REMI(
+        miditok.TokenizerConfig(num_velocities=62, pitch_range=(12, 44))
+    )
     num_tries = 0
     while num_tries < MAX_NUM_TRIES_HF_PUSH:
         try:
@@ -35,13 +50,26 @@ def test_push_and_load_to_hf_hub(hf_token: str):
     if num_tries == MAX_NUM_TRIES_HF_PUSH:
         warnings.warn("Tokenizer push failed", stacklevel=2)
 
-    tokenizer2 = REMI.from_pretrained("Natooz/MidiTok-tests", token=hf_token)
+    tokenizer2 = miditok.REMI.from_pretrained("Natooz/MidiTok-tests", token=hf_token)
     assert tokenizer == tokenizer2
 
 
 def test_from_pretrained_local(tmp_path: Path):
     # Here using paths to directories
-    tokenizer = TSD()
+    tokenizer = miditok.TSD()
     tokenizer.save_pretrained(tmp_path)
-    tokenizer2 = TSD.from_pretrained(tmp_path)
+    tokenizer2 = miditok.TSD.from_pretrained(tmp_path)
     assert tokenizer == tokenizer2
+
+
+@pytest.mark.parametrize("params_case", AUTO_TOKENIZER_CASES)
+def test_autotokenizer(tmp_path: Path, params_case: tuple[str, str, str]):
+    tok_class, save_path, tok_class2 = params_case
+
+    tokenizer = getattr(miditok, tok_class)()
+    tokenizer.save_pretrained(tmp_path / save_path)
+    tokenizer2 = getattr(miditok, tok_class2)(
+        params=tmp_path / save_path / "tokenizer.json"
+    )
+
+    assert (tokenizer == tokenizer2) == (tok_class == tok_class2)


### PR DESCRIPTION
Following #127, this PR adds a way to dynamically instantiate a tokenizer solely based on a configuration file.
For example, using `MIDITokenizer.from_pretrained(config_path)` is now similar to `TSD.from_pretrained(config_path)` if the config file was saved from a `TSD` tokenizer.

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--142.org.readthedocs.build/en/142/

<!-- readthedocs-preview miditok end -->