### PR TITLE
`create_duration_tuples` can create overlapping tuples

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]  # tensorflow not supported with 3.12
         os: [ ubuntu-latest, windows-latest ]
-        #include:  # TODO uncomment when multithreading pytest-xdist is fixed (PR #142)
-        #  - python-version: "3.11"
-        #    os: macos-latest
+        include:
+          - python-version: "3.11"
+            os: macos-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ sys.path.insert(0, str(Path("..").resolve()))
 project = "MidiTok"
 copyright = "2023, Nathan Fradet"  # noqa: A001
 author = "Nathan Fradet"
-release = "3.0.1"
+release = "3.0.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "miditok"
-version = "3.0.1"
+version = "3.0.2"
 description = "MIDI / symbolic music tokenizers for Deep Learning models."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Tokenization tests with this feature are not passing right now, `_time_ticks_to_tokens` have to be adapted to handle overlapping resolutions

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--144.org.readthedocs.build/en/144/

<!-- readthedocs-preview miditok end -->