### PR TITLE
Fix token_paths to files_paths, and config to model_config

### DIFF
--- a/colab-notebooks/Example_HuggingFace_Mistral_Transformer.ipynb
+++ b/colab-notebooks/Example_HuggingFace_Mistral_Transformer.ipynb
@@ -118,7 +118,7 @@
     "midi_paths = list(Path('Maestro').glob('**/*.mid')) + list(Path('Maestro').glob('**/*.midi'))\n",
     "tokenizer.learn_bpe(\n",
     "    vocab_size=10000,\n",
-    "    tokens_paths=midi_paths,\n",
+    "    files_paths=midi_paths,\n",
     "    start_from_empty_voc=False,\n",
     ")\n",
     "tokenizer.save_params(\"tokenizer.json\")\n",
@@ -175,7 +175,7 @@
     "    bos_token_id=tokenizer['BOS_None'],\n",
     "    eos_token_id=tokenizer['EOS_None'],\n",
     ")\n",
-    "model = AutoModelForCausalLM.from_config(config)"
+    "model = AutoModelForCausalLM.from_config(model_config)"
    ]
   },
   {


### PR DESCRIPTION
Hi, I was running this example notebook locally, which didn't work until introducing these two small fixes. So I propose a change for your consideration. Thanks!

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--145.org.readthedocs.build/en/145/

<!-- readthedocs-preview miditok end -->