### PR TITLE
Fixing `save_pretrained` to comply with huggingface_hub v0.21

### DIFF
--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -2770,6 +2770,44 @@ class MIDITokenizer(ABC, HFHubMixin):
 
         return self._convert_sequence_to_tokseq(json_content["ids"])
 
+    def save_pretrained(
+        self,
+        save_directory: str | Path,
+        *,
+        repo_id: str | None = None,
+        push_to_hub: bool = False,
+        **push_to_hub_kwargs,
+    ) -> str | None:
+        """
+        Save the tokenizer in local a directory.
+
+        Overridden from ``huggingface_hub.ModelHubMixin``.
+        Since v0.21 this method will automatically save ``self.config`` on after
+        calling ``self._save_pretrained``, which is unnecessary in our case.
+
+        :param save_directory: Path to directory in which the model weights and
+            configuration will be saved.
+        :param push_to_hub: Whether to push your model to the Huggingface Hub after
+            saving it.
+        :param repo_id: ID of your repository on the Hub. Used only if
+            `push_to_hub=True`. Will default to the folder name if not provided.
+        :param push_to_hub_kwargs: Additional key word arguments passed along to the
+            [`~ModelHubMixin.push_to_hub`] method.
+        """
+        save_directory = Path(save_directory)
+        save_directory.mkdir(parents=True, exist_ok=True)
+
+        # save model weights/files (framework-specific)
+        self._save_pretrained(save_directory)
+
+        # push to the Hub if required
+        if push_to_hub:
+            kwargs = push_to_hub_kwargs.copy()  # soft-copy to avoid mutating input
+            if repo_id is None:
+                repo_id = save_directory.name  # Defaults to `save_directory` name
+            return self.push_to_hub(repo_id=repo_id, **kwargs)
+        return None
+
     def _save_pretrained(self, *args, **kwargs) -> None:  # noqa: ANN002
         # called by `ModelHubMixin.from_pretrained`.
         self.save_params(*args, **kwargs)

--- a/tests/test_hf_hub.py
+++ b/tests/test_hf_hub.py
@@ -14,7 +14,7 @@ import miditok
 if TYPE_CHECKING:
     from pathlib import Path
 
-MAX_NUM_TRIES_HF_PUSH = 5
+MAX_NUM_TRIES_HF_PUSH = 3
 NUM_SECONDS_RETRY = 8
 
 AUTO_TOKENIZER_CASES = [


### PR DESCRIPTION
Since [`huggingface_hub` v0.21](https://github.com/huggingface/huggingface_hub/releases/tag/v0.21.0) `ModelHubMixin.save_pretrained` will automatically save ``self.config`` after calling ``self._save_pretrained``, which is unnecessary in our case as ``self._save_pretrained`` already saves the tokenizer's config.

This PR overrides `ModelHubMixin.save_pretrained` to get rid of the config logic.

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--150.org.readthedocs.build/en/150/

<!-- readthedocs-preview miditok end -->