### PR TITLE
`_model_name` is now a protected property

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ dataset = DatasetMIDI(
     bos_token_id=tokenizer["BOS_None"],
     eos_token_id=tokenizer["EOS_None"],
 )
-collator = DataCollator(tokenizer.pad_token_id)
+collator = DataCollator(tokenizer.pad_token_id, copy_inputs_as_labels=True)
 dataloader = DataLoader(dataset, batch_size=64, collate_fn=collator)
 
 # Iterate over the dataloader to train a model

--- a/docs/pytorch_data.rst
+++ b/docs/pytorch_data.rst
@@ -63,7 +63,7 @@ Here is a complete example showing how to use this module to train any model.
         bos_token_id=tokenizer["BOS_None"],
         eos_token_id=tokenizer["EOS_None"],
     )
-    collator = DataCollator(tokenizer.pad_token_id)
+    collator = DataCollator(tokenizer.pad_token_id, copy_inputs_as_labels=True)
     dataloader = DataLoader(dataset, batch_size=64, collate_fn=collator)
 
     # Iterate over the dataloader to train a model

--- a/miditok/midi_tokenizer.py
+++ b/miditok/midi_tokenizer.py
@@ -119,7 +119,6 @@ class MusicTokenizer(ABC, HFHubMixin):
         self._vocab_learned_bytes_to_tokens = {}
         # Fast tokenizer model backed with 🤗tokenizers
         self._model = None
-        self._model_name = None
         # Used in _notes_to_events, especially MIDILike
         self._note_on_off = False
         # Determines how the tokenizer will handle multiple tracks: either each track
@@ -297,6 +296,12 @@ class MusicTokenizer(ABC, HFHubMixin):
         if not self.is_trained:
             return None
         return self._model.get_vocab()
+
+    @property
+    def _model_name(self) -> str:
+        if self._model is None:
+            return "None"
+        return type(self._model.model).__name__
 
     @property
     def vocab_size(self) -> int:
@@ -2669,7 +2674,6 @@ class MusicTokenizer(ABC, HFHubMixin):
         }
 
         self._model = tokenizer
-        self._model_name = model_name
 
     @staticmethod
     def __reload_hf_tokenizer(tokenizer: _HFTokenizer) -> _HFTokenizer:


### PR DESCRIPTION
Fixing incorrect model __repr__ when loading a tokenizer from a file (not reporting the model's name)

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--165.org.readthedocs.build/en/165/

<!-- readthedocs-preview miditok end -->