### PR TITLE
small bug fix in MIDI pretokenization

### DIFF
--- a/miditok/pytorch_data/datasets.py
+++ b/miditok/pytorch_data/datasets.py
@@ -150,7 +150,7 @@ class DatasetMIDI(_DatasetABC):
         self.func_to_get_labels = func_to_get_labels
         self.sample_key_name = sample_key_name
         self.labels_key_name = labels_key_name
-        self.samples, self.labels = ([], []) if func_to_get_labels else (None, None)
+        self.samples, self.labels = [], [] if func_to_get_labels else None
 
         # Pre-tokenize the files
         if pre_tokenize:


### PR DESCRIPTION
If pre-tokenizing the dataset for training, the bug forces us to have func_to_get_labels.

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--170.org.readthedocs.build/en/170/

<!-- readthedocs-preview miditok end -->