### PR TITLE
fix import HfHubHTTPError with latest hf hub package update

### DIFF
--- a/tests/test_hf_hub.py
+++ b/tests/test_hf_hub.py
@@ -7,7 +7,7 @@ from time import sleep
 from typing import TYPE_CHECKING
 
 import pytest
-from huggingface_hub.utils._errors import HfHubHTTPError
+from huggingface_hub.utils import HfHubHTTPError
 
 import miditok
 


### PR DESCRIPTION


<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--199.org.readthedocs.build/en/199/

<!-- readthedocs-preview miditok end -->