### PR TITLE
Using --dist worksteal for tests distribution among workers

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.x"]
-        os: [ ubuntu-latest, macos-latest ]  # windows-latest is extremely slow
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:
       - uses: actions/checkout@v4
@@ -32,8 +32,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[tests]"
 
+      # Tokenizer training tests are significantly slower than others.
+      # So that xdist don't assign chunks of training tests to the same worker, we use
+      # the `--dist worksteal` distribution mode to dynamically reassign queued tests to
+      # free workers.
       - name: Test with pytest
-        run: pytest --cov=./ --cov-report=xml -n logical --durations=0 -v tests
+        run: pytest --cov=./ --cov-report=xml -n logical --dist worksteal --durations=0 -v tests
         env:
           HF_TOKEN_HUB_TESTS: ${{ secrets.HF_TOKEN_HUB_TESTS }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,11 @@ exclude = [
     ".venv",
 ]
 
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]
+
 [tool.coverage.report]
 exclude_also = [
     "def __repr__",


### PR DESCRIPTION
So that xdist don't assign chunks of training tests to the same worker, we use the `--dist worksteal` distribution mode to dynamically reassign queued tests to free workers.

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--201.org.readthedocs.build/en/201/

<!-- readthedocs-preview miditok end -->