### PR TITLE
bugfix training initial alphabet

### DIFF
--- a/src/miditok/midi_tokenizer.py
+++ b/src/miditok/midi_tokenizer.py
@@ -2760,8 +2760,8 @@ class MusicTokenizer(ABC, HFHubMixin):
         initial_alphabet = {
             chr(i + CHR_ID_START): i
             for tok, i in self._vocab_base.items()
-            if len(tok) == 1  # to discard special tokens with Unigram
-        }
+            if not tok.endswith(UNIGRAM_SPECIAL_TOKEN_SUFFIX)
+        }  # if to discard special tokens with Unigram
 
         # Define the model
         # A `tokenizers.Tokenizer` can feature: a normalizer, pre-tokenizer, model,


### PR DESCRIPTION
Fixing a bug where a tokenizer training discarded tokens present from the base vocabulary but not in the training data.

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--220.org.readthedocs.build/en/220/

<!-- readthedocs-preview miditok end -->