### PR TITLE
Add a parameter augment_copy to the augment_score function

### DIFF
--- a/src/miditok/data_augmentation/data_augmentation.py
+++ b/src/miditok/data_augmentation/data_augmentation.py
@@ -257,6 +257,7 @@ def augment_score(
     velocity_range: tuple[int, int] = (1, 127),
     duration_in_ticks: bool = False,
     min_duration: int | float = 0.03125,
+    augment_copy: bool = True
 ) -> Score:
     r"""
     Augment a Score object by shifting its pitch, velocity and/or duration values.
@@ -284,9 +285,12 @@ def augment_score(
     :param min_duration: minimum duration limit to apply if ``duration_offset`` is
         negative. If ``duration_in_ticks`` is ``True``, it must be given in ticks,
         otherwise in beats as a float or integer. (default: ``0.03125``)
+    :param augment_copy: if given True, a copy of the input ``symusic.Score`` object is
+        augmented and returned. If False, the input ``symusic.Score`` object is modified
+        in-place. (default: ``True``)
     :return: the augmented ``symusic.Score`` object.
     """
-    score_aug = score.copy()
+    score_aug = score.copy() if augment_copy else score
     # score_aug = score.copy(deep=True)
 
     if pitch_offset != 0:

--- a/src/miditok/data_augmentation/data_augmentation.py
+++ b/src/miditok/data_augmentation/data_augmentation.py
@@ -257,7 +257,7 @@ def augment_score(
     velocity_range: tuple[int, int] = (1, 127),
     duration_in_ticks: bool = False,
     min_duration: int | float = 0.03125,
-    augment_copy: bool = True
+    augment_copy: bool = True,
 ) -> Score:
     r"""
     Augment a Score object by shifting its pitch, velocity and/or duration values.


### PR DESCRIPTION
Hi!

This pull request introduces a new parameter 'augment_copy' to the augment_score function in the data_augmentation module. This enhancement provides users with more control over how the augmentation is applied to the input Score object.

Changes made:

1. Added a new boolean parameter 'augment_copy' with a default value of True.
2. Updated the function's docstring to include a description of the new parameter.
3. Modified the function logic to use the 'augment_copy' parameter when deciding whether to create a copy of the input Score object or modify it in-place.

The 'augment_copy' parameter allows users to choose between two behaviors:
- When True (default): A copy of the input symusic.Score object is augmented and returned, preserving the original object.
- When False: The input symusic.Score object is modified in-place, which can be more memory-efficient for large scores.

This change enhances the flexibility of the augment_score function, allowing users to optimize for either safety (by working on a copy) or performance (by modifying in-place) based on their specific use case.



<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--221.org.readthedocs.build/en/221/

<!-- readthedocs-preview miditok end -->