### PR TITLE
Fixing build target + using hatch in github actions

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Install pypa/build
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build --user
+          python -m pip install hatch --user
       - name: Build a binary wheel and a source tarball
-        run: python -m build
+        run: hatch build
       - name: Store the distribution packages
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -55,6 +55,6 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install dependencies
-        run: pip install build
+        run: pip install hatch
       - name: Build package
-        run: python -m build
+        run: hatch build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "miditok"
-version = "3.0.5"
+version = "3.0.5.post1"
 description = "MIDI / symbolic music tokenizers for Deep Learning models."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
@@ -66,7 +66,11 @@ Documentation = "https://miditok.readthedocs.io"
 Issues = "https://github.com/Natooz/MidiTok/issues"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/treeval"]
+packages = ["src/miditok"]
+only-packages = true
+
+[tool.hatch.version]
+path = "src/miditok/__init__.py"
 
 [mypy]
 warn_return_any = "True"


### PR DESCRIPTION
Fixing build error due to bad target path since the change to the "src" project structure, reported in #222 

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--223.org.readthedocs.build/en/223/

<!-- readthedocs-preview miditok end -->