### PR TITLE
Bugfix when loading trained `PerTok` tokenizer

### DIFF
--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
-from pathlib import Path
 
 import numpy as np
 from symusic import Note, Pedal, PitchBend, Score, Tempo, TimeSignature, Track
-from tokenizers import Tokenizer as _HFTokenizer
 
 from miditok.classes import Event, TokenizerConfig, TokSequence
 from miditok.constants import DEFAULT_VELOCITY, MIDI_INSTRUMENTS, TIME_SIGNATURE

--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -100,9 +100,8 @@ class PerTok(MusicTokenizer):
         ]
         # This will be hit when we're using microtiming
         # and have loaded a TRAINED tokenizer
-        if (
-                self.config.additional_params["use_microtiming"] and
-                not hasattr(self, "microtiming_tick_values")
+        if self.config.additional_params["use_microtiming"] and not hasattr(
+            self, "microtiming_tick_values"
         ):
             self.microtiming_tick_values = self.create_microtiming_tick_values()
 

--- a/tests/test_saving_loading_config.py
+++ b/tests/test_saving_loading_config.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, Any
 import miditok
 import pytest
 
-from .utils_tests import ALL_TOKENIZATIONS, MAX_BAR_EMBEDDING, MIDI_PATHS_MULTITRACK, MIDI_PATHS_ONE_TRACK
+from .utils_tests import (
+    ALL_TOKENIZATIONS,
+    MAX_BAR_EMBEDDING,
+    MIDI_PATHS_MULTITRACK,
+    MIDI_PATHS_ONE_TRACK,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -124,7 +129,7 @@ def test_multitrack_midi_to_tokens_to_midi(
 def test_pertok_microtiming_tick_values(file_path: Path):
     # Create the pertok tokenizer
     cfg = miditok.TokenizerConfig(
-        use_chords=False,    # False to speed up tests
+        use_chords=False,
         use_microtiming=True,
         ticks_per_quarter=480,
         max_microtiming_shift=0.25,

--- a/tests/test_saving_loading_config.py
+++ b/tests/test_saving_loading_config.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 import miditok
 import pytest
 
-from .utils_tests import ALL_TOKENIZATIONS, MAX_BAR_EMBEDDING, MIDI_PATHS_MULTITRACK
+from .utils_tests import ALL_TOKENIZATIONS, MAX_BAR_EMBEDDING, MIDI_PATHS_MULTITRACK, MIDI_PATHS_ONE_TRACK
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -118,3 +118,24 @@ def test_multitrack_midi_to_tokens_to_midi(
 
     # Assert tokens are the same
     assert tokens == tokens_loaded
+
+
+@pytest.mark.parametrize("file_path", MIDI_PATHS_ONE_TRACK[:3], ids=lambda p: p.name)
+def test_pertok_microtiming_tick_values(file_path: Path):
+    # Create the pertok tokenizer
+    cfg = miditok.TokenizerConfig(
+        use_chords=False,    # False to speed up tests
+        use_microtiming=True,
+        ticks_per_quarter=480,
+        max_microtiming_shift=0.25,
+        num_microtiming_bins=110,
+    )
+    tok = miditok.PerTok(cfg)
+    # Train the tokenizer
+    tok.train(files_paths=[file_path], vocab_size=1000)
+    # Dump the tokenizer to a JSON
+    tok.save("tmp.json")
+    # Reload the tokenizer
+    newtok = miditok.PerTok(params="tmp.json")
+    # Should still have the microtiming_tick_values parameter
+    assert hasattr(newtok, "microtiming_tick_values")


### PR DESCRIPTION
Hi, this PR fixes the issue I describe here: https://github.com/Natooz/MidiTok/issues/227

From what I can gather, the `microtiming_tick_values` attribute was previously only created when calling `_create_base_vocabulary`, which in turn was only called when `len(vocab) == 0` in the base `MusicTokenizer` class, see [this line](https://github.com/Natooz/MidiTok/blob/446c0417eb1851cca2063719f2b14e9b5cfcb867/src/miditok/midi_tokenizer.py#L254). This does not happen when loading a trained PerTok tokenizer as the vocabulary size is already greater than 0.

My fix is simply to move the creation of `microtiming_tick_values` into its own function, then call this at the end of `PerTok.__init__` if `use_microtiming = True` and the attribute hasn't already been set inside `_create_base_vocabulary`. Maybe better ways of doing it but this seems to work. Have also added a test inside `test_saving_loading_config`.

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--229.org.readthedocs.build/en/229/

<!-- readthedocs-preview miditok end -->