### PR TITLE
Fix error in PerTok decoding (MIDI conversion) when use_sustain_pedals=True

### DIFF
--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -511,22 +511,22 @@ class PerTok(MusicTokenizer):
                             ]
                             # Add instrument if it doesn't exist, can happen for the
                             # first tokens
-                            new_pedal = Pedal(current_tick, duration)
+                            new_pedal = Pedal(int(current_tick), int(duration)) 
                             if self.config.one_token_stream_for_programs:
                                 check_inst(pedal_prog)
                                 tracks[pedal_prog].pedals.append(new_pedal)
                             else:
                                 current_track.pedals.append(new_pedal)
                     elif pedal_prog not in active_pedals:
-                        active_pedals[pedal_prog] = current_tick
+                        active_pedals[pedal_prog] = int(current_tick)  
                 elif tok_type == "PedalOff":
                     pedal_prog = (
                         int(tok_val) if self.config.use_programs else current_program
                     )
                     if pedal_prog in active_pedals:
                         new_pedal = Pedal(
-                            active_pedals[pedal_prog],
-                            current_tick - active_pedals[pedal_prog],
+                            int(active_pedals[pedal_prog]).
+                            int(current_tick - active_pedals[pedal_prog]),
                         )
                         if self.config.one_token_stream_for_programs:
                             check_inst(pedal_prog)

--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -375,8 +375,8 @@ class PerTok(MusicTokenizer):
             curr_bar = 0
             current_program = 0
             previous_note_end = 0
-            previous_pitch_onset = {prog: -128 for prog in self.config.programs}
-            previous_pitch_chord = {prog: -128 for prog in self.config.programs}
+            previous_pitch_onset = dict.fromkeys(self.config.programs, -128)
+            previous_pitch_chord = dict.fromkeys(self.config.programs, -128)
             active_pedals = {}
             ticks_per_bar = ticks_per_beat * TIME_SIGNATURE[0]
 
@@ -511,22 +511,23 @@ class PerTok(MusicTokenizer):
                             ]
                             # Add instrument if it doesn't exist, can happen for the
                             # first tokens
-                            new_pedal = Pedal(int(current_tick), int(duration)) 
+                            new_pedal = Pedal(int(current_tick), int(duration))
                             if self.config.one_token_stream_for_programs:
                                 check_inst(pedal_prog)
                                 tracks[pedal_prog].pedals.append(new_pedal)
                             else:
                                 current_track.pedals.append(new_pedal)
                     elif pedal_prog not in active_pedals:
-                        active_pedals[pedal_prog] = int(current_tick)  
+                        active_pedals[pedal_prog] = int(current_tick)
                 elif tok_type == "PedalOff":
                     pedal_prog = (
                         int(tok_val) if self.config.use_programs else current_program
                     )
                     if pedal_prog in active_pedals:
                         new_pedal = Pedal(
-                            int(active_pedals[pedal_prog]).
-                            int(current_tick - active_pedals[pedal_prog]),
+                            int(active_pedals[pedal_prog]).int(
+                                current_tick - active_pedals[pedal_prog]
+                            ),
                         )
                         if self.config.one_token_stream_for_programs:
                             check_inst(pedal_prog)


### PR DESCRIPTION
### Description

This PR fixes a bug in the `PerTok` tokenizer that occurs during decoding (MIDI conversion) when `use_sustain_pedals=True` is set in the tokenizer configuration.

### Reproduction

The issue can be reproduced with the following code:

```python
from miditok import PerTok, TokenizerConfig
from symusic import Score

TOKENIZER_PARAMS = {
    "pitch_range": (21, 109),
    "beat_res": {(0, 4): 4, (0, 4): 3},
    "special_tokens": ["PAD", "BOS", "EOS", "MASK"],
    "use_chords": False,
    "use_rests": False,
    "use_tempos": False,
    "use_time_signatures": True,
    "use_programs": False,
    "use_microtiming": True,
    "ticks_per_quarter": 320,
    "max_microtiming_shift": 0.125,
    "num_microtiming_bins": 30,
    "use_sustain_pedals": True  # <-- sustain pedal enabled
}
config = TokenizerConfig(**TOKENIZER_PARAMS)
tokenizer = PerTok(config)

midi = Score('./Maestro_1.mid')
tokens = tokenizer(midi)
converted_back_midi = tokenizer(tokens)  # Error happens here
converted_back_midi.dump_midi("converted_back.mid")
```

### Error

```text
TypeError: __init__(): incompatible function arguments. The following argument types are supported:
1. __init__(self, other: symusic.core.PedalTick) -> None
2. __init__(self, time: int, duration: int) -> None

Invoked with types: symusic.core.PedalTick, int, float
```

### Environment

- Python 3.10  
- miditok + symusic

### Fix

Casting the `duration` value to `int` resolved the issue.


<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--232.org.readthedocs.build/en/232/

<!-- readthedocs-preview miditok end -->