### PR TITLE
Update split.py

### DIFF
--- a/src/miditok/utils/split.py
+++ b/src/miditok/utils/split.py
@@ -387,7 +387,7 @@ def split_tokens_files_to_subsequences(
             with path.open("w") as outfile:
                 new_tok = deepcopy(tokens)
                 new_tok["ids"] = subseq
-                json.dump(tokens, outfile)
+                json.dump(new_tok, outfile)
 
 
 def _preprocess_time_signatures(score: Score, tokenizer: MusicTokenizer) -> None:


### PR DESCRIPTION
The function aims to split token sequences and save each subsequence to a separate JSON file. However, the current implementation saves the entire original tokens dictionary (including all tracks/sequences) into each output file, instead of the new_tok dictionary which correctly contains only the single desired subsequence in its "ids" field.

The fix is to change the variable passed to json.dump when saving the output file, changing:
- json.dump(tokens, outfile)
to:
- json.dump(new_tok, outfile)

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--233.org.readthedocs.build/en/233/

<!-- readthedocs-preview miditok end -->