### PR TITLE
PerTok: Position tokens instead of Timeshift

### DIFF
--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -118,7 +118,9 @@ class PerTok(MusicTokenizer):
             self.config.additional_params["max_microtiming_shift"] * self.tpq
         )
 
-        self.use_position_toks: bool = self.config.additional_params.get("use_position_toks", False)
+        self.use_position_toks: bool = self.config.additional_params.get(
+            "use_position_toks", False
+        )
         self.position_locations = None
 
     def _create_base_vocabulary(self) -> list[str]:

--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -311,39 +311,41 @@ class PerTok(MusicTokenizer):
             time_delta = event.time - previous_tick
 
             # Option 1: Adding Position tokens
-            if event.type_ in self.microtime_events and self.use_position_toks:
-                position_in_bar = event.time - bar_time
-                pos = self._find_closest_position_tok(position_in_bar)
-                microtiming = position_in_bar - pos
-                if time_delta >= self.min_timeshift:
-                    all_events.append(
-                        Event(
-                            type_="Position",
-                            value=pos,
-                            time=event.time,
-                            desc=f"position {pos}"
+            if event.type_ in self.microtime_events:
+                
+                if self.use_position_toks:
+                    position_in_bar = event.time - bar_time
+                    pos = self._find_closest_position_tok(position_in_bar)
+                    microtiming = position_in_bar - pos
+                    if time_delta >= self.min_timeshift:
+                        all_events.append(
+                            Event(
+                                type_="Position",
+                                value=pos,
+                                time=event.time,
+                                desc=f"position {pos}"
+                            )
                         )
-                    )
-                    previous_tick = bar_time + pos
+                        previous_tick = bar_time + pos
 
 
-            # Option 2: creating Timeshift tokens
-            else:
-                timeshift = 0
-                if time_delta >= self.min_timeshift:
-                    ts_tuple = self._get_closest_duration_tuple(time_delta)
-                    ts = ".".join(str(x) for x in ts_tuple)
-                    all_events.append(
-                        Event(
-                            type_="TimeShift",
-                            value=ts,
-                            time=event.time,
-                            desc=f"timeshift {ts}",
+                # Option 2: creating Timeshift tokens
+                else:
+                    timeshift = 0
+                    if time_delta >= self.min_timeshift:
+                        ts_tuple = self._get_closest_duration_tuple(time_delta)
+                        ts = ".".join(str(x) for x in ts_tuple)
+                        all_events.append(
+                            Event(
+                                type_="TimeShift",
+                                value=ts,
+                                time=event.time,
+                                desc=f"timeshift {ts}",
+                            )
                         )
-                    )
-                    timeshift = ts_tuple[0] * ts_tuple[-1] + ts_tuple[1]
-                    previous_tick += timeshift
-                microtiming = time_delta - timeshift
+                        timeshift = ts_tuple[0] * ts_tuple[-1] + ts_tuple[1]
+                        previous_tick += timeshift
+                    microtiming = time_delta - timeshift
 
             all_events.append(event)
 

--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -137,7 +137,8 @@ class PerTok(MusicTokenizer):
                 f"Position_{pos}" for pos in self.position_locations
             ]
 
-        # PerTok's original version uses 'Timeshift' to denote delta between two note's positions
+        # PerTok's original version uses 'Timeshift' to denote delta between
+        # two note's positions
         else:
             vocab += [
                 f"TimeShift_{self._duration_tuple_to_str(duration)}"

--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -13,7 +13,6 @@ from miditok.midi_tokenizer import MusicTokenizer
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import Optional
     from numpy.typing import NDArray
     from symusic.core import TimeSignatureTickList
 
@@ -121,7 +120,6 @@ class PerTok(MusicTokenizer):
 
         self.use_position_toks: bool = self.config.additional_params.get("use_position_toks", False)
         self.position_locations = None
-        print(f"(remove this): using pos toks: {self.use_position_toks}")
 
     def _create_base_vocabulary(self) -> list[str]:
         vocab = ["Bar_None"]
@@ -246,9 +244,8 @@ class PerTok(MusicTokenizer):
         return durations
 
     # Utility Methods
-    def _get_closest_array_value(
-        self, value: int | float, array: NDArray
-    ) -> int | float:
+    @staticmethod
+    def _get_closest_array_value(value: int | float, array: NDArray) -> int | float:
         return array[np.abs(array - value).argmin()]
 
     def _get_closest_duration_tuple(self, target: int) -> tuple[int, int, int]:

--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -486,7 +486,7 @@ class PerTok(MusicTokenizer):
                     previous_pitch_chord[current_program] = pitch
 
                     try:
-                        if self.use_microtiming:
+                        if self.use_microtiming and "MicroTiming" in seq[ti + mt_offset]:
                             mt_type, mt = seq[ti + mt_offset].split("_")
                             mt = int(mt)
                         else:
@@ -509,7 +509,7 @@ class PerTok(MusicTokenizer):
                         ):
                             if isinstance(dur, str):
                                 dur = self._convert_durations_to_ticks(dur)
-                                # dur = self._tpb_tokens_to_ticks[ticks_per_beat][dur]
+
                             mt += current_tick
                             new_note = Note(int(mt), dur, pitch, int(vel))
                             if self.config.one_token_stream_for_programs:

--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -486,7 +486,8 @@ class PerTok(MusicTokenizer):
                     previous_pitch_chord[current_program] = pitch
 
                     try:
-                        if self.use_microtiming and "MicroTiming" in seq[ti + mt_offset]:
+                        if self.use_microtiming \
+                                and "MicroTiming" in seq[ti + mt_offset]:
                             mt_type, mt = seq[ti + mt_offset].split("_")
                             mt = int(mt)
                         else:

--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -13,6 +13,7 @@ from miditok.midi_tokenizer import MusicTokenizer
 
 if TYPE_CHECKING:
     from pathlib import Path
+
     from numpy.typing import NDArray
     from symusic.core import TimeSignatureTickList
 

--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -312,7 +312,7 @@ class PerTok(MusicTokenizer):
 
             # Option 1: Adding Position tokens
             if event.type_ in self.microtime_events:
-                
+
                 if self.use_position_toks:
                     position_in_bar = event.time - bar_time
                     pos = self._find_closest_position_tok(position_in_bar)

--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -264,9 +264,8 @@ class PerTok(MusicTokenizer):
         beats, subdiv, tpq = map(int, duration.split("."))
         return beats * tpq + subdiv
 
-    def _create_position_tok_locations(self):
-        positions = [0] + sorted(list(set((dur[0] * self.tpq) + dur[1] for dur in self.durations)))
-        return tuple(positions)
+    def _create_position_tok_locations(self) -> list[int]:
+        return [0, *sorted({(dur[0] * self.tpq) + dur[1] for dur in self.durations})]
 
     @staticmethod
     def _duration_tuple_to_str(duration_tuple: tuple[int, int, int]) -> str:


### PR DESCRIPTION
This PR adds an optional flag of `use_position_toks` in the TokenizerConfig. If set to `true`, it replaces all macro timeshift events with Position tokens, similar to REMI. However it retains the core MicroTime functionality for expressive timing. The implementation is backward compatible with previous versions of PerTok, and by default is set to `off`. 

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--236.org.readthedocs.build/en/236/

<!-- readthedocs-preview miditok end -->