### PR TITLE
Fix backwards compatibility with older PerTok versions

### DIFF
--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -106,6 +106,13 @@ class PerTok(MusicTokenizer):
         ):
             self.microtiming_tick_values = self.create_microtiming_tick_values()
 
+    def __setstate__(self, state):
+        # Load the state normally
+        self.__dict__.update(state)
+        # Set default for missing attribute
+        if not hasattr(self, 'use_position_toks'):
+            self.use_position_toks = False
+
     def _tweak_config_before_creating_voc(self) -> None:
         self.tpq = self.config.additional_params["ticks_per_quarter"]
         self.use_microtiming = self.config.additional_params["use_microtiming"]

--- a/src/miditok/tokenizations/pertok.py
+++ b/src/miditok/tokenizations/pertok.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from symusic import Note, Pedal, PitchBend, Score, Tempo, TimeSignature, Track
@@ -106,11 +106,12 @@ class PerTok(MusicTokenizer):
         ):
             self.microtiming_tick_values = self.create_microtiming_tick_values()
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore object state from pickle, setting defaults for missing attributes."""
         # Load the state normally
         self.__dict__.update(state)
         # Set default for missing attribute
-        if not hasattr(self, 'use_position_toks'):
+        if "use_position_toks" not in state:
             self.use_position_toks = False
 
     def _tweak_config_before_creating_voc(self) -> None:


### PR DESCRIPTION
If loading a PerTok tokenizer that was pickled before the 'Position toks' changes were introduced, it would fail. This PR fixes it by introducing a basic setstate method to default the Position toks to 'false'

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--243.org.readthedocs.build/en/243/

<!-- readthedocs-preview miditok end -->