### PR TITLE
fix: cast np_get_closest result to scalar before int() in Structured (NumPy 2.x)

### DIFF
--- a/src/miditok/tokenizations/structured.py
+++ b/src/miditok/tokenizations/structured.py
@@ -93,7 +93,7 @@ class Structured(MusicTokenizer):
                         np_get_closest(
                             self._tpb_to_time_array[ticks_per_beat],
                             np.array([time_shift_ticks]),
-                        )
+                        ).item()
                     )
                     time_shift = self._tpb_ticks_to_tokens[ticks_per_beat][
                         time_shift_ticks
@@ -182,7 +182,7 @@ class Structured(MusicTokenizer):
                         np_get_closest(
                             self._tpb_to_time_array[time_division],
                             np.array([time_shift_ticks]),
-                        )
+                        ).item()
                     )
                     time_shift = self._tpb_ticks_to_tokens[time_division][
                         time_shift_ticks


### PR DESCRIPTION
## Summary

`Structured._create_track_events` and `Structured._add_time_events` both call

```python
time_shift_ticks = int(
    np_get_closest(self._tpb_to_time_array[tpb], np.array([time_shift_ticks]))
)
```

`np_get_closest` returns a 1-D numpy array of size 1 (not a 0-d scalar). On NumPy 2.x, `int(arr)` on a non-0-d array raises:

```
TypeError: only 0-dimensional arrays can be converted to Python scalars
```

On NumPy 1.x this worked with a `DeprecationWarning`. With NumPy 2.x, any code path that tokenizes a `Score` with the `Structured` tokenizer dies — including parangonar's `TheGlueNoteMatcher`, which is how I hit this.

## Repro

```python
import numpy as np
import symusic
from miditok import Structured, TokenizerConfig

# Build any small Score (e.g. via symusic.Score.from_file or constructed).
score = symusic.Score(tpq=480)
track = symusic.core.TrackSecond("t", program=0, is_drum=False)
track.notes.append(symusic.core.NoteSecond(0, 0.5, 60, 80))
track.notes.append(symusic.core.NoteSecond(0.5, 0.5, 62, 80))
score.tracks.append(track)

tok = Structured(TokenizerConfig(use_velocities=True))
tok(score)  # TypeError on NumPy 2.x
```

## Fix

`.item()` after the call to extract the scalar, matching the return-type contract callers assume:

```python
time_shift_ticks = int(
    np_get_closest(
        self._tpb_to_time_array[ticks_per_beat],
        np.array([time_shift_ticks]),
    ).item()
)
```

Two-character change at each of two sites. No behavior change on NumPy 1.x; NumPy-2.x crash is gone.

The other `np_get_closest` call sites in `midi_tokenizer.py` use the returned array as an array (assigning to SoA fields), so they're already correct.

## Test plan
- [x] Verified `parangonar.TheGlueNoteMatcher()` runs end-to-end on installable Python 3.14 / NumPy 2.4 with this fork; without the fix it raises TypeError.
- [ ] Add a `Structured`-specific regression test for NumPy 2.x — happy to do this in a follow-up if the maintainers want it (the fix is mechanical enough that I held off on adding a tokenization-level test that requires a fixture Score).