### PR TITLE
Apply get_bars_ticks()'s only_notes_onsets off-by-one fix to get_beats_ticks()

### DIFF
--- a/src/miditok/utils/utils.py
+++ b/src/miditok/utils/utils.py
@@ -769,7 +769,11 @@ def get_beats_ticks(score: Score, only_notes_onsets: bool = False) -> list[int]:
     # Mock the last one to cover the last section in the loop below in all cases, as it
     # prevents the case in which the last time signature had an invalid numerator or
     # denominator (that would have been skipped in the while loop below).
-    time_sigs.append(TimeSignature(max_tick, *TIME_SIGNATURE))
+
+    # When only_notes_onsets is True, we add an extra tick because otherwise, when
+    # the last onset coincides with a start of a beat, it will be excluded because
+    # range() is exclusive of the endpoint.
+    time_sigs.append(TimeSignature(max_tick + int(only_notes_onsets), *TIME_SIGNATURE))
 
     # Section from tick 0 to first time sig is 4/4 if first time sig time is not 0
     if (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,7 @@ from miditok import REMI, TokenizerConfig
 from miditok.constants import CLASS_OF_INST
 from miditok.utils import (
     get_bars_ticks,
+    get_beats_ticks,
     merge_same_program_tracks,
     merge_tracks,
     merge_tracks_per_class,
@@ -368,6 +369,52 @@ _BAR = _TPQ * 4  # ticks per 4/4 bar
 )
 def test_get_bars_ticks(score: Score, only_notes_onsets: bool, expected: list[int]):
     assert get_bars_ticks(score, only_notes_onsets=only_notes_onsets) == expected
+
+
+_BEAT = _TPQ  # ticks per beat in 4/4
+
+
+@pytest.mark.parametrize(
+    ("score", "only_notes_onsets", "expected"),
+    [
+        # Regression: onsets land exactly on each beat — last beat must be included.
+        # Bug: ceil(max_onset / ticks_per_beat) is an integer, so the last beat is
+        # dropped.
+        (
+            _build_score([(i * _BEAT, _BEAT) for i in range(4)], _TPQ),
+            True,
+            [0, _BEAT, 2 * _BEAT, 3 * _BEAT],
+        ),
+        # Onsets offset by 1 tick — last onset (BEAT*2+1) is inside beat 2, beat 3
+        # excluded.
+        (
+            _build_score([(i * _BEAT + 1, _BEAT - 1) for i in range(3)], _TPQ),
+            True,
+            [0, _BEAT, 2 * _BEAT],
+        ),
+        # only_notes_onsets=False uses score.end() (note end, not onset), so a single
+        # note spanning 4 beats should yield 4 beat ticks.
+        (
+            _build_score([(0, 4 * _BEAT)], _TPQ),
+            False,
+            [0, _BEAT, 2 * _BEAT, 3 * _BEAT],
+        ),
+        # Single note at tick 0 — only beat 0 should be returned.
+        (
+            _build_score([(0, _TPQ)], _TPQ),
+            True,
+            [0],
+        ),
+    ],
+    ids=[
+        "onsets_on_beats",
+        "onsets_offset_by_one",
+        "only_notes_onsets_false",
+        "single_note_at_zero",
+    ],
+)
+def test_get_beats_ticks(score: Score, only_notes_onsets: bool, expected: list[int]):
+    assert get_beats_ticks(score, only_notes_onsets=only_notes_onsets) == expected
 
 
 @pytest.mark.parametrize("file_path", MIDI_PATHS_ONE_TRACK, ids=lambda p: p.name)


### PR DESCRIPTION
Closes #263

## What

#263 reported that `get_bars_ticks(score, only_notes_onsets=True)` drops
the final bar when the last note onset coincides exactly with a bar
boundary — `range()` is exclusive of its endpoint, so
`ceil(ticks_diff / ticks_per_bar)` coming out as an exact integer loses the
last one. #264 already fixed `get_bars_ticks()` for this.

`get_beats_ticks()` (same file, same structure) has the identical bug and
was never fixed: it still appends the sentinel time signature at
`max_tick` instead of `max_tick + int(only_notes_onsets)`. This applies the
exact same fix (and comment) that #264 already applied to `get_bars_ticks`.

## Testing

Added `test_get_beats_ticks`, mirroring the existing `test_get_bars_ticks`
parametrization (same `_build_score` helper, same case shapes: onsets
landing exactly on beat boundaries, an off-by-one-tick variant,
`only_notes_onsets=False`, and the empty/single-note edge case).

I don't have `symusic`/`pytest` installed in the environment I worked in
(no network-installable deps, no pip), so I couldn't run the test suite
directly. I did:
- Trace the arithmetic by hand for all 4 parametrized cases against both
  the old and new code, confirming the old code drops the last beat in the
  regression cases and the fix restores it, matching #264's fix exactly.
- Run `ruff check` and `ruff format --check` on both changed files (via a
  standalone `nix run nixpkgs#ruff`, since I don't have a Python
  environment for this repo) — both clean.

I'd appreciate a maintainer or CI running the actual test suite, since I
can't confirm that locally.

Marking this AI-assisted: this PR was authored by an AI coding agent
(Claude).
