### PR TITLE
Fix Python 2-style except syntax and TYPE_CHECKING-only imports used at runtime

### DIFF
--- a/src/miditok/midi_tokenizer.py
+++ b/src/miditok/midi_tokenizer.py
@@ -1846,7 +1846,7 @@ class MusicTokenizer(ABC, HFHubMixin):
         # Deduce the type of data (ids/tokens/events)
         try:
             arg = ("ids", convert_ids_tensors_to_list(input_seq))
-        except AttributeError, ValueError, TypeError, IndexError:
+        except (AttributeError, ValueError, TypeError, IndexError):
             if isinstance(input_seq[0], str) or (
                 isinstance(input_seq[0], list) and isinstance(input_seq[0][0], str)
             ):

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,5 +1,7 @@
 """Tests on the preprocessing steps of music files, before tokenization."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/test_toksequence.py
+++ b/tests/test_toksequence.py
@@ -1,5 +1,7 @@
 """Test methods."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest


### PR DESCRIPTION
Fix Python 2-style except syntax and TYPE_CHECKING-only imports used at runtime

The "fixes lint" commit (078efaa) introduced an invalid
`except A, B, C:` clause in midi_tokenizer.py, breaking `import miditok`
outright (SyntaxError). The same commit also moved `Path`/`Callable`
imports for two test files behind `if TYPE_CHECKING:` without adding
`from __future__ import annotations`, so their runtime-evaluated function
signatures raised NameError at collection time.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F2LDwE52Eq2QLWgBwx4tRf

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--285.org.readthedocs.build/en/285/

<!-- readthedocs-preview miditok end -->