### PR TITLE
Fix Python 2-style except syntax and TYPE_CHECKING-only imports used at runtime

### DIFF
--- a/src/miditok/midi_tokenizer.py
+++ b/src/miditok/midi_tokenizer.py
@@ -1846,7 +1846,7 @@ class MusicTokenizer(ABC, HFHubMixin):
         # Deduce the type of data (ids/tokens/events)
         try:
             arg = ("ids", convert_ids_tensors_to_list(input_seq))
-        except AttributeError, ValueError, TypeError, IndexError:
+        except (AttributeError, ValueError, TypeError, IndexError):
             if isinstance(input_seq[0], str) or (
                 isinstance(input_seq[0], list) and isinstance(input_seq[0][0], str)
             ):

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,5 +1,7 @@
 """Tests on the preprocessing steps of music files, before tokenization."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/test_toksequence.py
+++ b/tests/test_toksequence.py
@@ -1,5 +1,7 @@
 """Test methods."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest


### PR DESCRIPTION
Fix Python 2-style except syntax and TYPE_CHECKING-only imports used at runtime

Fix an invalid `except A, B, C:` clause in midi_tokenizer.py that broke `import miditok` with a SyntaxError. Add missing `from __future__ import annotations` to two test files whose runtime-evaluated signatures referenced TYPE_CHECKING-only imports (Path/Callable) under Python 3.10+.

<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--286.org.readthedocs.build/en/286/

<!-- readthedocs-preview miditok end -->