### PR TITLE
Fix CI: drop Python 3.9 from test matrix and enforce ruff format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,6 @@ jobs:
       - run: ruff check
         env:
           RUFF_OUTPUT_FORMAT: github
-      #- run: ruff format
-      #  env:
-      #    RUFF_OUTPUT_FORMAT: github
+      - run: ruff format --check
+        env:
+          RUFF_OUTPUT_FORMAT: github

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.12"]
+        python-version: ["3.10", "3.12", "3.13"]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,14 @@ docs = [
     # "sphinxcontrib-tikz",
 ]
 
+[dependency-groups]
+# Tools used to run checks locally, mirroring what the CI workflows enforce.
+# Install with `uv sync --group dev`.
+dev = [
+    "ruff",
+    "ty",
+]
+
 [project.urls]
 Homepage = "https://github.com/Natooz/MidiTok"
 Repository = "https://github.com/Natooz/MidiTok.git"


### PR DESCRIPTION
Fix CI: drop Python 3.9 from test matrix and enforce ruff format

- Test on the supported Python range (>=3.10); 3.9 can no longer install the project since requires-python was bumped, leaving the job permanently broken.
- Enable ruff format --check in the lint workflow.
- Add a dev dependency group (ruff, ty) so `uv sync --group dev` mirrors what CI runs.



<!-- readthedocs-preview miditok start -->
----
📚 Documentation preview 📚: https://miditok--287.org.readthedocs.build/en/287/

<!-- readthedocs-preview miditok end -->